### PR TITLE
Update obs dim doc and model_manager polish

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -24,8 +24,8 @@ scripts/       ←  all of the above
 Humanoid-v5 raw obs (350 dims)
   → StandingEnv/WalkingEnv processes to 365 dims
   → Append COM features (+6)
-  → [Walking only] Append command block (+9)
-  → Stack 4 frames → 1484 or 1493 dims
+  → [Walking only] Append command block (+11)
+  → Stack 4 frames → 1484 or 1495 dims
   → VecNormalize → normalized obs to PPO policy
   → PPO outputs 17-dim action
   → Action smoothing (EMA) → env.step()

--- a/src/training/model_manager.py
+++ b/src/training/model_manager.py
@@ -57,7 +57,7 @@ class ModelManager:
         self,
         task: str,
         base_dir: str = "models",
-        max_checkpoints_per_stage: int = 5,
+        max_checkpoints_per_stage: int = 3,
     ):
         """
         Initialize model manager.
@@ -142,7 +142,7 @@ class ModelManager:
         with open(self.latest_dir / "info.json", 'w') as f:
             json.dump(info, f, indent=2)
         
-        print(f"✓ Latest saved: {model_path}.zip")
+        print(f"[OK] Latest saved: {model_path}.zip")
     
     def save_checkpoint(
         self, 
@@ -185,7 +185,7 @@ class ModelManager:
         except (OSError, AttributeError) as e:
             logger.warning("Could not save vecnorm for checkpoint: %s", e)
 
-        print(f"✓ Checkpoint saved: {model_path}.zip")
+        print(f"[OK] Checkpoint saved: {model_path}.zip")
         
         # Cleanup old checkpoints
         self._cleanup_checkpoints(stage_dir)
@@ -258,7 +258,7 @@ class ModelManager:
         with open(self.final_dir / "info.json", 'w') as f:
             json.dump(info, f, indent=2)
         
-        print(f"✓ Final model saved: {model_path}.zip")
+        print(f"[OK] Final model saved: {model_path}.zip")
     
     def archive_config(self, config: Dict[str, Any], run_name: str = None):
         """
@@ -276,7 +276,7 @@ class ModelManager:
         with open(config_path, 'w') as f:
             yaml.dump(config, f, default_flow_style=False)
         
-        print(f"✓ Config archived: {config_path}")
+        print(f"[OK] Config archived: {config_path}")
     
     def _cleanup_checkpoints(self, stage_dir: Path):
         """Remove old checkpoints, keeping only the most recent N."""


### PR DESCRIPTION
Two small non-experiment improvements salvaged from feat/tip-nav-controller dirty state: doc fix for current obs dims, and Windows-console + checkpoint-count polish in model_manager.