### PR TITLE
Add missing CLAUDE.md files and fix stale links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ Standing (5M steps)  →  Transfer Learning  →  Walking (30M steps)  →  Maze
 | `src/core/` | Reward calculator + command generator | [CLAUDE.md](src/core/CLAUDE.md) |
 | `src/training/` | Transfer learning, model management, callbacks | [CLAUDE.md](src/training/CLAUDE.md) |
 | `src/maze/` | Procedural maze generation + navigation | [CLAUDE.md](src/maze/CLAUDE.md) |
-| `src/agents/` | High-level agent wrappers + diagnostics | — |
-| `src/utils/` | Visualization utilities | — |
+| `src/agents/` | High-level agent wrappers + diagnostics | [CLAUDE.md](src/agents/CLAUDE.md) |
+| `src/utils/` | Visualization + WandB utilities | [CLAUDE.md](src/utils/CLAUDE.md) |
 | `scripts/` | Training, evaluation, debug entry points | [CLAUDE.md](scripts/CLAUDE.md) |
 | `config/` | Single YAML config for all tasks | [CLAUDE.md](config/CLAUDE.md) |
 | `models/` | Trained weights + VecNormalize stats | — |

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -40,6 +40,23 @@ Key args: `--from-standing` (enable transfer), `--model`, `--vecnorm`, `--timest
 
 Adds `CommandStatsProtectorCallback` (re-pins command stats every 10k steps) and `WalkingMetricsCallback` (curriculum progress every 50 episodes). Uses `WalkingCurriculumEnv` with 3 stages.
 
+## Model Surgery
+
+### `expand_obs_dims.py`
+
+Expands a saved walking model from 1493 obs dims (9-dim command block) to 1495 (11-dim) by inserting `yaw_actual` and `err_yaw` into the command block. Operates on both the policy weights (zero-initialized new columns) and the VecNormalize stats (identity stats for new dims).
+
+```bash
+python scripts/expand_obs_dims.py \
+    --model models/walking/final/final_walking_model.zip \
+    --vecnorm models/walking/final/vecnorm_walking.pkl \
+    --output-model models/walking/final/expanded_walking_model.zip \
+    --output-vecnorm models/walking/final/expanded_vecnorm.pkl
+```
+
+New command block layout after expansion:
+`[vx_cmd, vy_cmd, yaw_cmd, vx_actual, vy_actual, yaw_actual, err_vx, err_vy, err_speed, err_angle, err_yaw]`
+
 ## Evaluation
 
 ### `evaluate.py`

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -38,3 +38,6 @@ Humanoid-v5 raw obs (350 dims)
 - [environments/CLAUDE.md](environments/CLAUDE.md) — Observation/action spaces, curriculum, termination
 - [core/CLAUDE.md](core/CLAUDE.md) — Reward math, command generator
 - [training/CLAUDE.md](training/CLAUDE.md) — Transfer learning, model management, safety callbacks
+- [agents/CLAUDE.md](agents/CLAUDE.md) — StandingAgent, StandingCallback, DiagnosticsCallback
+- [utils/CLAUDE.md](utils/CLAUDE.md) — Visualization, WandB callbacks, platform helpers
+- [maze/CLAUDE.md](maze/CLAUDE.md) — Procedural maze generation, A* solver, pure pursuit navigation

--- a/src/agents/CLAUDE.md
+++ b/src/agents/CLAUDE.md
@@ -1,0 +1,63 @@
+# src/agents/ — High-Level Agent Wrappers + Diagnostics
+
+## `standing_agent.py`
+
+### StandingAgent
+
+High-level PPO agent for standing task. Wraps environment creation, model construction, training, evaluation, and checkpoint management in one object. Configured entirely from the `standing` section of `config/training_config.yaml`.
+
+Key methods:
+
+| Method | Purpose |
+|--------|---------|
+| `create_environment()` | Builds `SubprocVecEnv` (n_envs > 1) or `DummyVecEnv`, wraps in `VecNormalize` |
+| `create_model()` | Creates PPO with architecture from config; handles string→`torch.nn` activation mapping |
+| `train(total_timesteps)` | Runs `.learn()` with `StandingCallback` + `EarlyStoppingCallback` |
+| `evaluate(n_episodes)` | Deterministic rollouts; reports height error, stability, reward |
+| `analyze_standing_performance(n_episodes)` | Debug mode — prints per-episode breakdown and early-termination rate |
+| `load_model(path)` | Loads model + restores matching `VecNormalize` stats |
+
+### StandingCallback(BaseCallback)
+
+Unified SB3 callback for standing training. Handles:
+- **WandB logging** every `log_freq` steps: height distribution, XY drift, action magnitudes, policy `log_std`
+- **Evaluation** every `eval_freq` steps via `eval_env_fn()`; saves best model by mean reward
+- **Video recording** every `video_freq` steps (WandB only)
+- **Checkpointing** every `save_freq` steps; co-saves `VecNormalize` `.pkl` alongside model `.zip`
+
+VecNormalize is saved before every evaluation run to keep stats in sync with the model.
+
+### EarlyStoppingCallback(BaseCallback)
+
+Stops training when standing is mastered. Checks every `check_freq` steps across 5 evaluation episodes. Success requires all of: `mean_reward > target`, `height_error < target`, `height_stability < target`, `mean_length > min_episode_length`. Requires `patience` consecutive checks before stopping.
+
+### `create_standing_agent(config_path, device, use_wandb)`
+
+Convenience function for quick setup. Loads `config/training_config.yaml`, extracts the `standing` section, auto-detects CUDA, and returns a `StandingAgent`.
+
+---
+
+## `diagnostics.py`
+
+### DiagnosticsCallback(BaseCallback)
+
+Unified diagnostics for both tasks. Logs to WandB every `log_freq` steps using rolling buffers (last 5000 steps).
+
+**Standing metrics logged (`diag/` prefix):**
+- Height: mean, std, p10, p90, min, max
+- Height distribution bins: `<1.0`, `1.0–1.2`, `1.2–1.35`, `1.35–1.45`, `>1.45`
+- Action magnitude: mean, std, p10, p90, max
+- Reward: mean, std
+
+**Walking metrics added (`diag/` prefix):**
+- Velocity error: mean, std, p10, p50, p90, max
+- Velocity error distribution bins: `<0.1`, `0.1–0.3`, `0.3–0.5`, `0.5–1.0`, `>1.0`
+- Commanded speed mean/max, actual speed mean/std/max
+- Speed tracking ratio (`actual/commanded`, valid commands only)
+- XY drift: mean and max distance from origin
+
+Instantiate with `task="walking"` to enable walking-specific metric collection.
+
+### WalkingDiagnosticsCallback(DiagnosticsCallback)
+
+Thin subclass of `DiagnosticsCallback` with `task="walking"` default. Preferred entry point for walking training scripts.

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -1,0 +1,64 @@
+# src/utils/ — Visualization + WandB Utilities
+
+## `__init__.py` — Platform Helpers
+
+Two functions exported at package level:
+
+| Function | Purpose |
+|----------|---------|
+| `configure_mujoco_gl()` | Sets `MUJOCO_GL=egl` on Linux (headless GPU). No-op on macOS/Windows. Call before importing MuJoCo envs. |
+| `get_subprocess_start_method()` | Returns `"spawn"` (Windows), `"fork"` (macOS), or `"forkserver"` (Linux) for `SubprocVecEnv`. |
+
+---
+
+## `visualization.py`
+
+### `setup_display()`
+
+Calls `configure_mujoco_gl()` and prints the resulting `MUJOCO_GL` value. Use at the top of scripts that render frames.
+
+### `test_environment(env) → bool`
+
+Smoke-tests a gymnasium env: resets, renders one frame, steps once, renders again. Checks that the frame is a 3-channel `np.ndarray`. Returns `True` on success. Useful for verifying render modes before recording video.
+
+---
+
+## `wandb_callbacks.py`
+
+### VelocityTrackingWandBCallback(BaseCallback)
+
+Comprehensive WandB callback for walking training. Uses rolling `deque` buffers (default 1000 steps).
+
+**Logs at `log_freq` steps:**
+- `train/velocity_error` — episode-end errors only (not step-wise, avoids fall spikes)
+- `train/velocity_error_x/y` — per-axis errors
+- `train/jerk_penalty`, `train/action_magnitude`
+- `train/height_mean/std`
+- `episode/reward_mean/std`, `episode/length_mean/std`
+- `curriculum/stage`, `curriculum/avg_stage`
+
+Logs curriculum `stage_history` table on training end.
+
+### CurriculumWandBCallback(BaseCallback)
+
+Focused on curriculum progression. Tracks episode-end velocity errors per stage (not step-wise). Logs `curriculum/stage_advanced` and `curriculum/advancement_timestep` on every stage transition. Per-stage metrics use last 20 episodes for stable estimates; tolerance shrinks with stage (`0.7 - 0.05 × stage`).
+
+### VideoRecordingCallback(BaseCallback)
+
+Records evaluation rollouts and uploads to WandB as mp4. Runs every `video_freq` steps. Resets the eval env on episode termination to avoid short clips.
+
+### `init_wandb_run(project, name, config, tags) → bool`
+
+Helper to initialize a WandB run with `reinit=True`. Returns `False` gracefully if WandB is not installed.
+
+### `finish_wandb_run()`
+
+Calls `wandb.finish()`. Use at the end of training scripts to flush all pending logs.
+
+---
+
+## `plot_velocity_commands.py`
+
+### `simulate_and_plot(duration, dt, seed, save_path)`
+
+Simulates `VelocityCommandGenerator` for `duration` seconds at `dt` timestep and produces a matplotlib figure showing step-like command changes (`vx`, `vy`, `yaw_rate`) over time. Demonstrates the uniform command sampling pattern and zero-velocity braking periods. Saves to `save_path` if provided.


### PR DESCRIPTION
## Summary

- Add `src/agents/CLAUDE.md` — documents `StandingAgent`, `StandingCallback`, `EarlyStoppingCallback`, `DiagnosticsCallback`, and `WalkingDiagnosticsCallback` (previously undocumented)
- Add `src/utils/CLAUDE.md` — documents visualization helpers, WandB callbacks (`VelocityTrackingWandBCallback`, `CurriculumWandBCallback`, `VideoRecordingCallback`), and platform utilities (previously undocumented)
- Wire new files into root `CLAUDE.md` directory map and `src/CLAUDE.md` subdirectory links; also add `src/maze/` link (file existed, wasn't linked)
- Add `expand_obs_dims.py` to `scripts/CLAUDE.md` with full usage example and new 11-dim command block layout

## Test plan

- [ ] Confirm all linked CLAUDE.md files exist at their stated paths
- [ ] Confirm key numbers in root CLAUDE.md (1495 obs dims, +11 command block) match `scripts/expand_obs_dims.py` and `src/environments/CLAUDE.md`
- [ ] Confirm `src/CLAUDE.md` data flow comment matches environments docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)