### PR TITLE
Sim-to-real deployment package (proprioceptive standing)

### DIFF
--- a/config/joint_servo_map.yaml
+++ b/config/joint_servo_map.yaml
@@ -1,0 +1,62 @@
+# joint_servo_map.yaml
+# MuJoCo action/qpos index  <->  physical servo-ID map for humanoid_real_v2.xml.
+# Deployment item #1. Built 2026-06-16 from models/humanoid_real_v2.xml (authoritative
+# actuator/joint order) cross-checked vs memory project-servo-mapping + project-hinge-directions.
+#
+# action[i] (policy output, radians) and qpos[7+i] (obs joint angle) use THIS SAME index i
+# (MJCF actuator order == joint definition order — verified).
+#
+# Deploy conversion per joint:
+#   target_units = servo_center + sign * (sim_rad) * units_per_rad
+#   target_units = clip(target_units, servo_min, servo_max)
+# servo_center = 512 (home = sim 0 = straight), units_per_rad ~= 195 (1.5708 rad = 306 units).
+# SCS servos are 10-bit (0..1023).
+#
+# sign_verified: true  = direction confirmed on the bare servo (only the 4 hinges so far).
+#                false = NOT yet tested; sign is a best guess, MUST verify on bare servo
+#                before driving under load (per project-hinge-directions: "the 13 symmetric
+#                joints' signs still need per-joint testing").
+
+units_per_rad: 195
+servo_center: 512
+
+# Home / nominal joint pose (sim radians), MJCF <key name="home"> qpos[7:24], in joint
+# (= action) index order. The proprioceptive obs reports joint angle RELATIVE to this
+# (jpos_obs = encoder_rad - default_joint_pos). NOTE this is a BENT pose, not zeros, so
+# at power-on (servos straight at 512 = sim 0) the robot must ramp to ~these angles before
+# the policy is in-distribution — deploy_standing.py does that ramp.
+default_joint_pos: [-0.06023, 0.95993, -0.32092, 0.0292, -0.0185, 1.13261, -0.09577,
+                    0.27894, -0.09589, -0.08487, -0.20783, -0.03803, -0.00268, 0.00409,
+                    0.03624, -0.00246, -0.00409]
+
+joints:
+  # ---- RIGHT LEG (roll, yaw, pitch, knee) -- DOF high-confidence via axis ----
+  - {idx: 0,  mjcf: "Revolute 18", dof: "R_hip_roll",   axis: x, sim_range: [-1.5708, 0.3491], servo_id: 4,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 1,  mjcf: "Revolute 26", dof: "R_hip_yaw",    axis: z, sim_range: [-1.5708, 0.9599], servo_id: 5,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 2,  mjcf: "Revolute 23", dof: "R_hip_pitch",  axis: y, sim_range: [-1.5708, 0.3491], servo_id: 6,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 3,  mjcf: "Revolute 21", dof: "R_knee",       axis: y, sim_range: [-1.5708, 1.5708], servo_id: 7,  sign: -1, sign_verified: true,  servo_limit: [206, 512]}  # hinge, INVERTED
+
+  # ---- LEFT LEG ----
+  - {idx: 4,  mjcf: "Revolute 24", dof: "L_hip_roll",   axis: x, sim_range: [-1.5708, 0.1745], servo_id: 8,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 5,  mjcf: "Revolute 28", dof: "L_hip_yaw",    axis: z, sim_range: [-0.9599, 1.5708], servo_id: 9,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 6,  mjcf: "Revolute 25", dof: "L_hip_pitch",  axis: y, sim_range: [-1.5708, 0.3491], servo_id: 10, sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 7,  mjcf: "Revolute 27", dof: "L_knee",       axis: y, sim_range: [-1.5708, 1.5708], servo_id: 11, sign: +1, sign_verified: true,  servo_limit: [512, 818]}  # hinge, normal
+
+  # ---- WAIST (roll, pitch, yaw) ----
+  - {idx: 8,  mjcf: "Revolute 22", dof: "waist_roll",   axis: x, sim_range: [-0.6109, 0.6109], servo_id: 3,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 9,  mjcf: "Revolute 20", dof: "waist_pitch",  axis: y, sim_range: [-0.3491, 1.5708], servo_id: 2,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 10, mjcf: "Revolute 19", dof: "waist_yaw",    axis: z, sim_range: [-1.5708, 1.5708], servo_id: 1,  sign: +1, sign_verified: false, servo_limit: [411, 613]}
+
+  # ---- RIGHT ARM (shoulder-pitch, shoulder-roll?, elbow) ----
+  # NOTE: MJCF arm kinematics = 2 shoulder DOF + elbow (NO wrist), but servo memory labels
+  # IDs 12/13/14 as shoulder/elbow/wrist. idx 12 (Rev 6) is most likely shoulder-ROLL, not a
+  # wrist. The servo_id<->DOF for the MIDDLE arm joint (14/17) must be RECONCILED with physical
+  # wiring before trusting it.
+  - {idx: 11, mjcf: "Revolute 2",  dof: "R_shoulder_pitch", axis: y, sim_range: [-2.0944, 2.0944], servo_id: 12, sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 12, mjcf: "Revolute 6",  dof: "R_shoulder_roll?", axis: x, sim_range: [-1.5708, 0.4363], servo_id: 14, sign: +1, sign_verified: false, servo_limit: [411, 613]}  # DOF/ID unconfirmed
+  - {idx: 13, mjcf: "Revolute 1",  dof: "R_elbow",          axis: y, sim_range: [ 0.0000, 2.0944], servo_id: 13, sign: +1, sign_verified: true,  servo_limit: [512, 818]}  # hinge, normal
+
+  # ---- LEFT ARM ----
+  - {idx: 14, mjcf: "Revolute 4",  dof: "L_shoulder_pitch", axis: y, sim_range: [-2.0944, 2.0944], servo_id: 15, sign: +1, sign_verified: false, servo_limit: [411, 613]}
+  - {idx: 15, mjcf: "Revolute 5",  dof: "L_shoulder_roll?", axis: x, sim_range: [-2.0071, 0.0000], servo_id: 17, sign: +1, sign_verified: false, servo_limit: [411, 613]}  # DOF/ID unconfirmed
+  - {idx: 16, mjcf: "Revolute 3",  dof: "L_elbow",          axis: y, sim_range: [-2.0944, 0.0000], servo_id: 16, sign: -1, sign_verified: true,  servo_limit: [206, 512]}  # hinge, INVERTED

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -1,0 +1,48 @@
+# Deploy — proprioceptive standing on the real robot
+
+Sim-to-real for the 19M tau=0.3 standing policy (`models/final_real_standing_model.zip`).
+All files here run **on the Pi** except the `--dry-run` paths, which run anywhere.
+
+## Files
+| File | Role |
+|------|------|
+| `sim_real_map.py` | Single source of truth for index↔servo↔sign↔limit + rad/units conversion. Loads `config/joint_servo_map.yaml`. |
+| `hardware.py` | **The hardware seam.** `ServoBus` (scservo_sdk SCSCL) + `IMU` (ICM-20948). Reconcile with your Pi driver HERE only. |
+| `verify_signs.py` | Bench tool: confirm which servo each action index drives and its sign. Writes results back into the map. |
+| `deploy_standing.py` | The closed-loop inference loop. |
+
+## Order of operations
+1. **Validate wiring (any machine):** `python scripts/deploy/deploy_standing.py --dry-run`
+   — loads model+vecnorm+map, builds the 228-dim obs, prints the first action + servo units. No hardware.
+2. **Wire `hardware.py`** to your actual Pi servo/IMU calls (the `TODO`/`NotImplementedError` spots).
+3. **Calibrate the IMU axis remap** (`IMU.axis_remap`) so accel/gyro land in the sim base frame
+   (handoff item #2). With the robot held upright, `projected_gravity()` must read ≈ `[0,0,-1]`.
+4. **Verify signs on the bench (robot supported):**
+   `python scripts/deploy/verify_signs.py --apply`
+   — turns the 13 `sign_verified: false` joints into tested entries and resolves the arm-DOF labels.
+5. **First closed loop, supported/hanging:**
+   `python scripts/deploy/deploy_standing.py --require-verified`
+   — refuses to run until every sign is bench-verified.
+
+## What is trustworthy now vs. needs the bench
+- **Solid (from MJCF + tested memories):** all leg + waist DOF/servo mapping; the 4 hinge signs
+  (idx 3,7,13,16 = knees/elbows); the obs construction; rad↔units math; tau=0.3 smoothing.
+- **NOT yet verified (placeholders):** the 13 non-hinge signs are all `+1` guesses — your own
+  notes say these need per-joint bench testing. **Do not drive under load before step 4.**
+- **Ambiguous:** the middle arm joint (idx 12/15, "shoulder_roll?") DOF↔servo-ID — the MJCF arm is
+  shoulder×2 + elbow (no wrist), but the servo memory labels IDs 12/13/14 shoulder/elbow/wrist.
+  `verify_signs.py` resolves this by showing which joint actually moves.
+
+## Critical invariants (do not change without retraining)
+- **tau=0.3** action smoothing is part of the trained closed loop — `deploy_standing.py --tau` must stay 0.3.
+- **Home keyframe** `default_joint_pos` (in the map) is a *bent* pose; obs joint angle is reported
+  relative to it. The loop ramps to it before going closed-loop.
+- **40 Hz** control rate (dt=0.025) matches sim.
+- Feed `-normalize(accel)` as projected gravity (accel at rest reads +1g UP = −proj_grav).
+
+## Safety in `deploy_standing.py`
+- Open-loop ramp to home before closed loop (`--ramp-secs`).
+- Tilt cutoff: cuts torque if `upright_cos < 0.5` (~60° tilt) — same threshold as the sim termination.
+- Per-step servo move clamp (`--max-step-units`) rate-limits any wild command.
+- Ctrl-C ramps to home and disables torque.
+- FSR foot contact stays OFF (obs is 228, not 230) — matches the trained model.

--- a/scripts/deploy/deploy_standing.py
+++ b/scripts/deploy/deploy_standing.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# deploy_standing.py
+"""
+Real-robot inference loop for the proprioceptive standing policy (RUN ON THE PI).
+
+Pipeline (must match src/environments/standing_env.py exactly):
+  sensors -> per-frame feature (57) -> 4-frame history (228) -> VecNormalize -> PPO.predict
+  -> tau=0.3 action smoothing -> clip to sim range -> rad->units (sign/limit) -> servo write
+
+Per-frame feature order (standing_env._proprioceptive_features):
+  proj_grav(3) | base_ang_vel(3) | (jpos - default_joint_pos)(17) | jvel(17) | last_action(17)
+History: last 4 frames, LEFT-padded with zeros until filled, concatenated oldest->newest.
+
+Defaults match the deployed model:
+  model  models/final_real_standing_model.zip   (19M, tau=0.3)
+  vecnorm models/vecnorm_real_standing.pkl
+  tau 0.3, control 40 Hz.
+
+  python scripts/deploy/deploy_standing.py --dry-run     # no hardware: load+predict once, print
+  python scripts/deploy/deploy_standing.py               # closed loop on the Pi
+"""
+
+from __future__ import annotations
+import argparse
+import pickle
+import sys
+import time
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sim_real_map import SimRealMap, DEFAULT_MAP  # noqa: E402
+
+NJ = 17
+FRAME = 6 + 3 * NJ          # 57
+HISTORY = 4
+OBS_DIM = FRAME * HISTORY   # 228
+
+
+def load_vecnorm_stats(path):
+    with open(path, "rb") as f:
+        vn = pickle.load(f)
+    mean = np.asarray(vn.obs_rms.mean, dtype=np.float32)
+    var = np.asarray(vn.obs_rms.var, dtype=np.float32)
+    eps = float(getattr(vn, "epsilon", 1e-8))
+    clip = float(getattr(vn, "clip_obs", 50.0))
+    assert mean.shape[0] == OBS_DIM, f"vecnorm obs dim {mean.shape[0]} != {OBS_DIM}"
+    return mean, var, eps, clip
+
+
+def normalize(obs, mean, var, eps, clip):
+    return np.clip((obs - mean) / np.sqrt(var + eps), -clip, clip).astype(np.float32)
+
+
+class ObsBuilder:
+    """Maintains history + finite-diff joint velocity, emits the 228-dim obs."""
+
+    def __init__(self, m: SimRealMap, dt: float):
+        self.m = m
+        self.dt = dt
+        self.hist = deque(maxlen=HISTORY)
+        self.prev_jpos = None
+        self.last_action = np.zeros(NJ, dtype=np.float32)  # smoothed target (sim rad), env init=0
+
+    def frame(self, proj_grav, ang_vel, jpos):
+        if self.prev_jpos is None:
+            jvel = np.zeros(NJ, dtype=np.float32)
+        else:
+            jvel = ((jpos - self.prev_jpos) / self.dt).astype(np.float32)
+        self.prev_jpos = jpos.copy()
+        return np.concatenate([proj_grav, ang_vel, jpos, jvel, self.last_action]).astype(np.float32)
+
+    def obs(self, frame):
+        self.hist.append(frame)
+        frames = list(self.hist)
+        if len(frames) < HISTORY:
+            frames = [np.zeros(FRAME, dtype=np.float32)] * (HISTORY - len(frames)) + frames
+        return np.concatenate(frames).astype(np.float32)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=str(ROOT / "models" / "final_real_standing_model.zip"))
+    p.add_argument("--vecnorm", default=str(ROOT / "models" / "vecnorm_real_standing.pkl"))
+    p.add_argument("--map", default=str(DEFAULT_MAP))
+    p.add_argument("--tau", type=float, default=0.3, help="action smoothing (MUST match training)")
+    p.add_argument("--hz", type=float, default=40.0)
+    p.add_argument("--ramp-secs", type=float, default=2.0, help="open-loop ramp to home before closed loop")
+    p.add_argument("--tilt-cut", type=float, default=0.5, help="hold+cut torque if upright_cos < this (~60deg)")
+    p.add_argument("--max-step-units", type=int, default=80, help="per-joint per-step servo move clamp")
+    p.add_argument("--speed", type=int, default=0, help="servo move speed (0=max)")
+    p.add_argument("--require-verified", action="store_true",
+                   help="refuse to drive joints whose sign is not bench-verified")
+    p.add_argument("--dry-run", action="store_true", help="no hardware: load, predict once with zero sensors, print")
+    args = p.parse_args()
+
+    dt = 1.0 / args.hz
+    m = SimRealMap(args.map)
+    home_units = m.rad_to_units(m.default_joint_pos)
+
+    unverified = m.unverified_idxs()
+    if unverified:
+        msg = f"[warn] {len(unverified)} joints have UNVERIFIED sign: {unverified} (run verify_signs.py)"
+        if args.require_verified:
+            print(msg + " -- aborting (--require-verified).")
+            return
+        print(msg)
+
+    # ---- load policy + normalization ----
+    from stable_baselines3 import PPO  # noqa: E402
+    print(f"Loading model {args.model}")
+    model = PPO.load(args.model, device="cpu")
+    mean, var, eps, clip = load_vecnorm_stats(args.vecnorm)
+    print(f"VecNormalize stats OK (obs_dim={OBS_DIM}, clip={clip})")
+
+    builder = ObsBuilder(m, dt)
+
+    def predict_units(proj_grav, ang_vel, jpos):
+        frame = builder.frame(proj_grav, ang_vel, jpos)
+        obs = builder.obs(frame)
+        raw_action = model.predict(normalize(obs, mean, var, eps, clip), deterministic=True)[0]
+        raw_action = np.asarray(raw_action, dtype=np.float32).ravel()
+        # Match StandingEnv._process_action: SB3 clips the action to the space BEFORE the
+        # env smooths it, so clip raw -> EMA-smooth -> clip again.
+        raw_action = np.clip(raw_action, m.range_lo, m.range_hi)
+        applied = (1.0 - args.tau) * builder.last_action + args.tau * raw_action
+        applied = np.clip(applied, m.range_lo, m.range_hi)
+        builder.last_action = applied
+        return m.rad_to_units(applied), applied
+
+    if args.dry_run:
+        pg = np.array([0, 0, -1], dtype=np.float32)   # perfectly upright
+        av = np.zeros(3, dtype=np.float32)
+        jpos = np.zeros(NJ, dtype=np.float32)         # at home (encoder==default -> jpos 0)
+        for step in range(HISTORY):                   # fill history
+            units, applied = predict_units(pg, av, jpos)
+        print("\n[dry-run] first deterministic action (sim rad):")
+        print(np.array2string(applied, precision=3, suppress_small=True))
+        print("[dry-run] -> servo units:")
+        for i in range(NJ):
+            print(f"  {m.joints[i].dof:<18} servo {m.servo_ids[i]:2d}: {int(units[i])}")
+        print("\n[dry-run] OK: model + vecnorm + map wired correctly. No hardware touched.")
+        return
+
+    # ---- hardware ----
+    from hardware import ServoBus, IMU  # noqa: E402
+    bus = ServoBus().connect()
+    imu = IMU().connect()
+
+    def read_sensors():
+        pg = imu.projected_gravity()
+        av = imu.angular_velocity()
+        units = bus.read_all(m.servo_ids)
+        jpos = (m.units_to_rad(units) - m.default_joint_pos).astype(np.float32)
+        return pg, av, jpos
+
+    try:
+        print("Enabling torque, calibrating gyro, ramping to home...")
+        bus.set_torque(m.servo_ids, True)
+        cur = bus.read_all(m.servo_ids)
+        steps = max(1, int(args.ramp_secs / dt))
+        for k in range(1, steps + 1):
+            u = (cur + (home_units - cur) * k / steps).round().astype(int)
+            bus.write_all(m.servo_ids, u, speed=args.speed)
+            time.sleep(dt)
+        imu.calibrate_gyro_bias(seconds=1.5)
+
+        # warm up history with real frames at rest
+        for _ in range(HISTORY):
+            pg, av, jpos = read_sensors()
+            builder.obs(builder.frame(pg, av, jpos))
+            time.sleep(dt)
+
+        print("Closed loop running (Ctrl-C to stop).")
+        prev_units = home_units.copy().astype(float)
+        while True:
+            t0 = time.time()
+            pg, av, jpos = read_sensors()
+
+            upright_cos = -float(pg[2])
+            if upright_cos < args.tilt_cut:
+                print(f"\n[SAFETY] upright_cos={upright_cos:.2f} < {args.tilt_cut}: cutting torque.")
+                bus.set_torque(m.servo_ids, False)
+                break
+
+            units, _ = predict_units(pg, av, jpos)
+            # per-step move clamp (rate limit), then write
+            units = np.clip(units, prev_units - args.max_step_units, prev_units + args.max_step_units)
+            units = np.clip(units, m.lim_lo, m.lim_hi).round().astype(int)
+            bus.write_all(m.servo_ids, units, speed=args.speed)
+            prev_units = units.astype(float)
+
+            time.sleep(max(0.0, dt - (time.time() - t0)))
+    except KeyboardInterrupt:
+        print("\nStopping: ramping to home and disabling torque.")
+        try:
+            cur = bus.read_all(m.servo_ids)
+            steps = max(1, int(1.0 / dt))
+            for k in range(1, steps + 1):
+                u = (cur + (home_units - cur) * k / steps).round().astype(int)
+                bus.write_all(m.servo_ids, u, speed=args.speed)
+                time.sleep(dt)
+        except Exception:
+            pass
+    finally:
+        bus.set_torque(m.servo_ids, False)
+        bus.close()
+        imu.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/hardware.py
+++ b/scripts/deploy/hardware.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# hardware.py
+"""
+Hardware seam: servo bus + IMU drivers for the Raspberry Pi.
+
+>>> THIS IS THE ONE FILE TO RECONCILE WITH YOUR EXISTING Pi DRIVER. <<<
+The servo control code (set_limits.py / home.json / the SCS SDK calls) lives on the Pi,
+not in this repo, so the calls below are written against the standard Waveshare/Feetech
+`scservo_sdk` (SCSCL protocol for SCS-series servos) and `smbus2` for the ICM-20948.
+If your Pi uses different call signatures, change them HERE only — the rest of the deploy
+code talks to ServoBus / IMU, not the SDK.
+
+All hardware imports are lazy so this module imports fine on the dev machine (Windows)
+for logic/unit testing; they only fail if you actually open the bus without the libs.
+"""
+
+from __future__ import annotations
+import time
+import numpy as np
+
+# Memory project-servo-mapping: /dev/ttyAMA0, 1000000 baud, Waveshare driver board.
+DEFAULT_PORT = "/dev/ttyAMA0"
+DEFAULT_BAUD = 1_000_000
+
+
+class ServoBus:
+    """Thin wrapper over scservo_sdk SCSCL. Positions are in raw servo units (0..1023)."""
+
+    def __init__(self, port: str = DEFAULT_PORT, baud: int = DEFAULT_BAUD):
+        self.port, self.baud = port, baud
+        self._ph = None   # PortHandler
+        self._pk = None   # scscl packet handler
+
+    def connect(self):
+        # Lazy import so the dev machine can import this module without the SDK.
+        from scservo_sdk import PortHandler, scscl  # type: ignore
+        self._ph = PortHandler(self.port)
+        if not self._ph.openPort():
+            raise RuntimeError(f"failed to open {self.port}")
+        if not self._ph.setBaudRate(self.baud):
+            raise RuntimeError(f"failed to set baud {self.baud}")
+        self._pk = scscl(self._ph)
+        return self
+
+    # ---- per-servo ops (servo_id is the physical bus ID 1..17) ----
+    def read_pos(self, servo_id: int) -> int:
+        pos, _, comm, err = self._pk.ReadPos(servo_id)
+        if comm != 0 or err != 0:
+            raise IOError(f"ReadPos id={servo_id} comm={comm} err={err}")
+        return int(pos)
+
+    def write_pos(self, servo_id: int, units: int, speed: int = 0, accel: int = 0):
+        # SCSCL.WritePos(id, position, time, speed). time=0 -> use speed.
+        comm, err = self._pk.WritePos(servo_id, int(units), 0, int(speed))
+        if comm != 0 or err != 0:
+            raise IOError(f"WritePos id={servo_id} comm={comm} err={err}")
+
+    def read_all(self, servo_ids) -> np.ndarray:
+        return np.array([self.read_pos(i) for i in servo_ids], dtype=np.float32)
+
+    def write_all(self, servo_ids, units, speed: int = 0):
+        for sid, u in zip(servo_ids, np.asarray(units).tolist()):
+            self.write_pos(int(sid), int(u), speed=speed)
+
+    def set_torque(self, servo_ids, enable: bool):
+        for sid in servo_ids:
+            try:
+                self._pk.write1ByteTxRx(int(sid), 40, 1 if enable else 0)  # reg 40 = torque enable
+            except Exception:
+                pass
+
+    def close(self):
+        if self._ph is not None:
+            try:
+                self._ph.closePort()
+            except Exception:
+                pass
+
+
+class IMU:
+    """ICM-20948 accel+gyro over I2C (memory project-sensor-bringup: 0x68, NCS->3.3V for I2C).
+
+    Returns vectors already remapped into the SIM BASE FRAME via `axis_remap` (a 3x3 signed
+    permutation you calibrate once), so proj_grav / ang_vel match what standing_env computed.
+    """
+
+    def __init__(self, addr: int = 0x68, axis_remap: np.ndarray | None = None):
+        self.addr = addr
+        self._bus = None
+        # Identity by default. MUST be calibrated to the physical IMU mounting (handoff item #2).
+        self.axis_remap = np.eye(3, dtype=np.float32) if axis_remap is None else np.asarray(axis_remap, np.float32)
+        self.gyro_bias = np.zeros(3, dtype=np.float32)
+
+    def connect(self):
+        from smbus2 import SMBus  # type: ignore
+        self._bus = SMBus(1)
+        # TODO: wake from sleep + set ranges per ICM-20948 datasheet (PWR_MGMT_1, etc.).
+        # Left to your existing bring-up code; values below assume it's already configured.
+        return self
+
+    def _read_accel_raw(self) -> np.ndarray:
+        # TODO: replace with your ICM-20948 register reads. Must return g-units, sensor frame.
+        raise NotImplementedError("wire to your ICM-20948 accel registers")
+
+    def _read_gyro_raw(self) -> np.ndarray:
+        # TODO: replace with your ICM-20948 register reads. Must return rad/s, sensor frame.
+        raise NotImplementedError("wire to your ICM-20948 gyro registers")
+
+    def projected_gravity(self) -> np.ndarray:
+        """proj_grav in sim base frame. At rest accel reads +1g UP = -proj_grav, so feed
+        -normalize(accel) (handoff). Valid when quasi-static (true for standing)."""
+        a = self._read_accel_raw().astype(np.float32)
+        n = np.linalg.norm(a)
+        a = a / n if n > 1e-6 else a
+        return (self.axis_remap @ (-a)).astype(np.float32)
+
+    def angular_velocity(self) -> np.ndarray:
+        """base_ang_vel (rad/s) in sim base frame = remapped gyro minus bias."""
+        g = self._read_gyro_raw().astype(np.float32)
+        return (self.axis_remap @ g - self.gyro_bias).astype(np.float32)
+
+    def calibrate_gyro_bias(self, seconds: float = 2.0, hz: float = 100.0):
+        """Average the (remapped) gyro while the robot is held still."""
+        n = max(1, int(seconds * hz))
+        acc = np.zeros(3, dtype=np.float32)
+        for _ in range(n):
+            acc += self.axis_remap @ self._read_gyro_raw().astype(np.float32)
+            time.sleep(1.0 / hz)
+        self.gyro_bias = acc / n
+        return self.gyro_bias
+
+    def close(self):
+        if self._bus is not None:
+            try:
+                self._bus.close()
+            except Exception:
+                pass

--- a/scripts/deploy/home.py
+++ b/scripts/deploy/home.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# home.py  --  RUN ON THE PI
+"""
+Standalone "everything back to home" / bench-reset for the SCS servo bus.
+
+Smoothly ramps all 17 servos to 512 (raw neutral), WAITS long enough for them to
+physically get there, then disables torque so the robot goes limp.
+
+Self-contained: only needs scservo_sdk (no repo imports). Copy-paste onto the Pi.
+
+  python3 home.py                 # ramp to 512 over 2s, settle, torque off
+  python3 home.py --hold          # ramp to 512, settle, KEEP torque on (holds pose)
+  python3 home.py --secs 3        # slower 3s ramp
+  python3 home.py --settle 2.0    # extra wait after the ramp before relaxing
+"""
+
+import argparse
+import time
+
+from scservo_sdk import PortHandler, scscl
+
+PORT = "/dev/ttyAMA0"
+BAUD = 1_000_000
+SERVO_IDS = list(range(1, 18))   # 1..17
+HOME = 512                       # raw neutral (10-bit center)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--secs", type=float, default=2.0, help="ramp duration to home")
+    p.add_argument("--settle", type=float, default=1.0,
+                   help="extra wait after ramp before disabling torque")
+    p.add_argument("--hz", type=float, default=50.0, help="ramp update rate")
+    p.add_argument("--speed", type=int, default=300, help="per-move servo speed (0=max)")
+    p.add_argument("--hold", action="store_true", help="keep torque on after homing")
+    args = p.parse_args()
+
+    ph = PortHandler(PORT)
+    if not ph.openPort():
+        raise RuntimeError(f"failed to open {PORT}")
+    if not ph.setBaudRate(BAUD):
+        raise RuntimeError(f"failed to set baud {BAUD}")
+    pk = scscl(ph)
+
+    dt = 1.0 / args.hz
+    steps = max(1, int(args.secs / dt))
+
+    # Enable torque so the servos actually drive to home.
+    for sid in SERVO_IDS:
+        try:
+            pk.write1ByteTxRx(sid, 40, 1)  # reg 40 = torque enable
+        except Exception as e:
+            print(f"  [warn] torque-enable id {sid}: {e}")
+
+    # Read current positions (fall back to HOME if a servo doesn't answer).
+    start = {}
+    for sid in SERVO_IDS:
+        try:
+            pos, _, comm, err = pk.ReadPos(sid)
+            start[sid] = int(pos) if (comm == 0 and err == 0) else HOME
+        except Exception:
+            start[sid] = HOME
+    print("Start positions:", {k: start[k] for k in SERVO_IDS})
+
+    # Smooth linear ramp every servo from its current pos -> 512.
+    print(f"Ramping {len(SERVO_IDS)} servos to {HOME} over {args.secs:.1f}s...")
+    for k in range(1, steps + 1):
+        frac = k / steps
+        for sid in SERVO_IDS:
+            tgt = int(round(start[sid] + (HOME - start[sid]) * frac))
+            try:
+                pk.WritePos(sid, tgt, 0, args.speed)  # WritePos(id, pos, time=0, speed)
+            except Exception as e:
+                print(f"  [warn] WritePos id {sid}: {e}")
+        time.sleep(dt)
+
+    # Make sure they're all commanded exactly to home, then let them finish moving.
+    for sid in SERVO_IDS:
+        try:
+            pk.WritePos(sid, HOME, 0, args.speed)
+        except Exception:
+            pass
+    print(f"Settling {args.settle:.1f}s so servos reach home...")
+    time.sleep(args.settle)
+
+    if args.hold:
+        print("Done. Torque LEFT ON (holding home).")
+    else:
+        for sid in SERVO_IDS:
+            try:
+                pk.write1ByteTxRx(sid, 40, 0)  # torque disable -> limp
+            except Exception:
+                pass
+        print("Done. Torque OFF (robot is limp at home).")
+
+    ph.closePort()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/requirements-deploy.txt
+++ b/scripts/deploy/requirements-deploy.txt
@@ -1,0 +1,15 @@
+# Minimal deps to run scripts/deploy/ on the Raspberry Pi.
+# The Pi does NOT need mujoco / gymnasium / the training stack — only these.
+# Versions pinned to the dev machine that trained the model, so PPO.load() doesn't
+# hit a version-mismatch error.
+
+numpy==2.4.6
+pyyaml==6.0.3
+stable-baselines3==2.8.0
+torch==2.12.0          # CPU build. On Pi OS use piwheels (https://www.piwheels.org/) or
+                       # the official aarch64 wheel; the +cpu suffix is fine.
+
+# --- hardware libs (Pi only; hardware.py lazy-imports them, so --dry-run works without) ---
+# smbus2                 # ICM-20948 over I2C
+# feetech-servo-sdk      # SCS bus servos (a.k.a. scservo_sdk). If you use Waveshare's
+#                        # vendored scservo_sdk source instead, drop it on the PYTHONPATH.

--- a/scripts/deploy/sim_real_map.py
+++ b/scripts/deploy/sim_real_map.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# sim_real_map.py
+"""
+Shared sim <-> hardware joint map and unit conversions for the real humanoid.
+
+Single source of truth = config/joint_servo_map.yaml (built from humanoid_real_v2.xml).
+Both verify_signs.py and deploy_standing.py import this so the index/sign/limit logic
+lives in exactly one place.
+
+Index convention: action[i] (policy output) and qpos[7+i] (obs joint angle) share the
+SAME index i, which is also this module's joint order (MJCF actuator == joint order).
+
+Unit conversion (per joint i):
+    units = center + sign[i] * sim_rad * units_per_rad          # rad -> servo units
+    sim_rad = sign[i] * (units - center) / units_per_rad        # servo units -> rad
+center = 512 (home), units_per_rad ~= 195. SCS servos are 10-bit (0..1023).
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from pathlib import Path
+import numpy as np
+import yaml
+
+DEFAULT_MAP = Path(__file__).resolve().parents[2] / "config" / "joint_servo_map.yaml"
+
+
+@dataclass
+class Joint:
+    idx: int
+    mjcf: str
+    dof: str
+    servo_id: int
+    sign: int
+    sign_verified: bool
+    servo_limit: tuple[int, int]
+    sim_range: tuple[float, float]
+
+
+class SimRealMap:
+    def __init__(self, path: str | Path = DEFAULT_MAP):
+        with open(path) as f:
+            d = yaml.safe_load(f)
+        self.units_per_rad = float(d["units_per_rad"])
+        self.center = int(d["servo_center"])
+        self.default_joint_pos = np.asarray(d["default_joint_pos"], dtype=np.float32)
+        self.joints: list[Joint] = []
+        for j in sorted(d["joints"], key=lambda x: x["idx"]):
+            self.joints.append(Joint(
+                idx=j["idx"], mjcf=j["mjcf"], dof=j["dof"], servo_id=j["servo_id"],
+                sign=int(j["sign"]), sign_verified=bool(j["sign_verified"]),
+                servo_limit=tuple(j["servo_limit"]), sim_range=tuple(j["sim_range"]),
+            ))
+        self.n = len(self.joints)
+        assert self.n == len(self.default_joint_pos) == 17, "expected 17 joints"
+        # vectorized views, in index order
+        self.servo_ids = np.array([j.servo_id for j in self.joints], dtype=int)
+        self.signs = np.array([j.sign for j in self.joints], dtype=np.float32)
+        self.lim_lo = np.array([j.servo_limit[0] for j in self.joints], dtype=np.float32)
+        self.lim_hi = np.array([j.servo_limit[1] for j in self.joints], dtype=np.float32)
+        self.range_lo = np.array([j.sim_range[0] for j in self.joints], dtype=np.float32)
+        self.range_hi = np.array([j.sim_range[1] for j in self.joints], dtype=np.float32)
+        self.verified = np.array([j.sign_verified for j in self.joints], dtype=bool)
+
+    # ---- conversions (vectorized over the 17 joints) ----
+    def rad_to_units(self, sim_rad: np.ndarray) -> np.ndarray:
+        sim_rad = np.clip(np.asarray(sim_rad, dtype=np.float32), self.range_lo, self.range_hi)
+        units = self.center + self.signs * sim_rad * self.units_per_rad
+        return np.clip(units, self.lim_lo, self.lim_hi).round().astype(int)
+
+    def units_to_rad(self, units: np.ndarray) -> np.ndarray:
+        units = np.asarray(units, dtype=np.float32)
+        return (self.signs * (units - self.center) / self.units_per_rad).astype(np.float32)
+
+    def unverified_idxs(self) -> list[int]:
+        return [j.idx for j in self.joints if not j.sign_verified]
+
+    def describe(self, idx: int) -> str:
+        j = self.joints[idx]
+        v = "verified" if j.sign_verified else "UNVERIFIED"
+        return (f"idx {j.idx:2d}  {j.mjcf:<12} {j.dof:<18} servo {j.servo_id:2d}  "
+                f"sign {j.sign:+d} ({v})  limit {j.servo_limit}")
+
+
+if __name__ == "__main__":
+    m = SimRealMap()
+    print(f"Loaded {m.n} joints, center={m.center}, units/rad={m.units_per_rad}")
+    for i in range(m.n):
+        print(m.describe(i))
+    print("\nUnverified-sign indices (need bench test):", m.unverified_idxs())

--- a/scripts/deploy/verify_signs.py
+++ b/scripts/deploy/verify_signs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# verify_signs.py
+"""
+Bench tool (RUN ON THE PI): confirm, for each MJCF action index, (1) which physical servo
+moves and (2) whether +sim_rad produces the physically intended direction. Converts the 13
+`sign_verified: false` joints in config/joint_servo_map.yaml into tested entries, and resolves
+the ambiguous arm-DOF labels by letting you see which joint actually moves.
+
+SAFETY: moves ONE joint at a time, a small angle, slowly, with the rest held at home. Start
+with the robot supported/hanging so a wrong sign can't tip it. Hinges already verified (idx
+3,7,13,16) are skipped unless you pass --include-verified.
+
+Per joint it commands home -> home+delta -> home-delta -> home, then asks:
+  [y] correct joint moved the intended + direction   -> keep sign, mark verified
+  [r] correct joint moved, but reversed              -> FLIP sign, mark verified
+  [w] WRONG joint moved                              -> leave unverified, flag servo_id/DOF
+  [s] skip   [q] quit
+
+Usage:
+  python scripts/deploy/verify_signs.py                 # test all unverified joints (interactive)
+  python scripts/deploy/verify_signs.py --only 2 6      # just these indices
+  python scripts/deploy/verify_signs.py --delta-rad 0.1 --speed 200
+  python scripts/deploy/verify_signs.py --apply         # write results back into the yaml
+  python scripts/deploy/verify_signs.py --dry-run       # no hardware; print the plan
+"""
+
+from __future__ import annotations
+import argparse
+import re
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sim_real_map import SimRealMap, DEFAULT_MAP  # noqa: E402
+
+
+def ramp_to(bus, servo_ids, start_units, goal_units, steps=40, dt=0.02, speed=150):
+    start = np.asarray(start_units, dtype=np.float32)
+    goal = np.asarray(goal_units, dtype=np.float32)
+    for k in range(1, steps + 1):
+        u = (start + (goal - start) * k / steps).round().astype(int)
+        bus.write_all(servo_ids, u, speed=speed)
+        time.sleep(dt)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--map", default=str(DEFAULT_MAP))
+    p.add_argument("--only", type=int, nargs="*", default=None, help="action indices to test")
+    p.add_argument("--include-verified", action="store_true")
+    p.add_argument("--delta-rad", type=float, default=0.12, help="probe amplitude (sim rad)")
+    p.add_argument("--speed", type=int, default=150)
+    p.add_argument("--apply", action="store_true", help="write sign/sign_verified back into the yaml")
+    p.add_argument("--dry-run", action="store_true", help="no hardware; just print the plan")
+    args = p.parse_args()
+
+    m = SimRealMap(args.map)
+
+    if args.only is not None:
+        targets = args.only
+    else:
+        targets = list(range(m.n)) if args.include_verified else m.unverified_idxs()
+    print(f"Joints to test: {targets}\n")
+
+    bus = None
+    home_units = m.rad_to_units(m.default_joint_pos)  # nominal pose in units, index order
+    if not args.dry_run:
+        from hardware import ServoBus  # noqa: E402
+        bus = ServoBus().connect()
+        bus.set_torque(m.servo_ids, True)
+        print("Holding all joints at home pose...")
+        cur = bus.read_all(m.servo_ids)
+        ramp_to(bus, m.servo_ids, cur, home_units, speed=args.speed)
+        time.sleep(0.5)
+
+    results: dict[int, dict] = {}
+    try:
+        for idx in targets:
+            j = m.joints[idx]
+            print("\n" + "=" * 70)
+            print(f"TEST {m.describe(idx)}")
+            print(f"  expect: physical servo {j.servo_id} ({j.dof}) moves on +{args.delta_rad} rad")
+            if args.dry_run:
+                u_plus = m.rad_to_units(_one_hot(m, idx, +args.delta_rad))[idx]
+                u_minus = m.rad_to_units(_one_hot(m, idx, -args.delta_rad))[idx]
+                print(f"  [dry-run] home={home_units[idx]} +d->{u_plus} -d->{u_minus}")
+                continue
+
+            base = home_units.copy()
+            # +delta
+            tgt = base.copy()
+            tgt[idx] = m.rad_to_units(_one_hot(m, idx, +args.delta_rad))[idx]
+            ramp_to(bus, [j.servo_id], [base[idx]], [tgt[idx]], speed=args.speed)
+            time.sleep(0.4)
+            # back to home, then -delta
+            ramp_to(bus, [j.servo_id], [tgt[idx]], [base[idx]], speed=args.speed)
+            tgt[idx] = m.rad_to_units(_one_hot(m, idx, -args.delta_rad))[idx]
+            ramp_to(bus, [j.servo_id], [base[idx]], [tgt[idx]], speed=args.speed)
+            time.sleep(0.4)
+            ramp_to(bus, [j.servo_id], [tgt[idx]], [base[idx]], speed=args.speed)
+
+            ans = input("  [y]correct  [r]reversed  [w]wrong joint  [s]skip  [q]quit > ").strip().lower()
+            if ans == "q":
+                break
+            if ans == "s":
+                continue
+            if ans == "y":
+                results[idx] = {"sign": j.sign, "sign_verified": True}
+            elif ans == "r":
+                results[idx] = {"sign": -j.sign, "sign_verified": True}
+            elif ans == "w":
+                results[idx] = {"sign": j.sign, "sign_verified": False, "note": "WRONG JOINT - check servo_id/DOF"}
+    finally:
+        if bus is not None:
+            print("\nReturning to home and disabling torque...")
+            cur = bus.read_all(m.servo_ids)
+            ramp_to(bus, m.servo_ids, cur, home_units, speed=args.speed)
+            bus.set_torque(m.servo_ids, False)
+            bus.close()
+
+    # ---- report ----
+    print("\n" + "=" * 70 + "\nRESULTS")
+    for idx in targets:
+        if idx in results:
+            r = results[idx]
+            tag = "VERIFIED" if r["sign_verified"] else "FLAGGED"
+            print(f"  idx {idx:2d} {m.joints[idx].dof:<18} sign {r['sign']:+d}  {tag} {r.get('note','')}")
+        else:
+            print(f"  idx {idx:2d} {m.joints[idx].dof:<18} (untested)")
+
+    if args.apply and results:
+        _apply_to_yaml(args.map, results)
+        print(f"\nWrote verified signs into {args.map}")
+    elif results:
+        print("\n(use --apply to write these back into the yaml)")
+
+
+def _one_hot(m: SimRealMap, idx: int, delta: float) -> np.ndarray:
+    """default pose with a single joint nudged by delta sim-rad."""
+    v = m.default_joint_pos.copy()
+    v[idx] = v[idx] + delta
+    return v
+
+
+def _apply_to_yaml(path: str, results: dict[int, dict]):
+    """In-place edit of the per-joint lines, preserving comments/formatting.
+    Each joint is one line:  - {idx: N, ..., sign: S, sign_verified: B, ...}"""
+    text = Path(path).read_text().splitlines()
+    out = []
+    for line in text:
+        mobj = re.search(r"idx:\s*(\d+)\b", line)
+        if mobj and line.lstrip().startswith("- {") and int(mobj.group(1)) in results:
+            r = results[int(mobj.group(1))]
+            line = re.sub(r"sign:\s*[+-]?\d+", f"sign: {r['sign']:+d}", line)
+            line = re.sub(r"sign_verified:\s*\w+", f"sign_verified: {str(r['sign_verified']).lower()}", line)
+        out.append(line)
+    Path(path).write_text("\n".join(out) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Deployment package to run the 19M tau=0.3 proprioceptive standing policy on the physical humanoid (Raspberry Pi).

## Contents (`scripts/deploy/`)
- **`sim_real_map.py`** — single source of truth: action-index ↔ servo-ID ↔ sign/limit, rad↔units conversion. Loads `config/joint_servo_map.yaml` (built from `humanoid_real_v2.xml`).
- **`deploy_standing.py`** — 40 Hz closed loop reproducing the exact 228-dim proprioceptive obs (`proj_grav | gyro | jpos−home | jvel | last_action` ×4 history) → VecNormalize → policy → tau=0.3 smoothing → servos. Startup ramp + tilt-cut safety. `--dry-run` validates wiring with no hardware.
- **`verify_signs.py`** — bench tool to confirm each joint's servo mapping + sign.
- **`hardware.py`** — `ServoBus` (scservo_sdk) + `IMU` (ICM-20948) hardware seam.
- **`home.py`** — standalone servo-home/reset utility.
- **`README.md`**, **`requirements-deploy.txt`** — Pi setup (minimal deps; no mujoco/training stack).

## Notes
- Only the **4 hinge signs** are bench-verified; the other 13 are placeholders pending `verify_signs.py` (`deploy_standing.py --require-verified` refuses to run until verified).
- `config/joint_servo_map.yaml` carries the home keyframe pose and the index↔servo map.
- Validated locally via `deploy_standing.py --dry-run` (model + vecnorm + obs + map wire correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)