### PR TITLE
Proprioceptive deployable standing (228-dim obs, yaw fix, jitter fine-tune)

### DIFF
--- a/config/real_humanoid_config.yaml
+++ b/config/real_humanoid_config.yaml
@@ -7,7 +7,13 @@
 
 standing:
   # ========== ENVIRONMENT ==========
-  xml_file: models/humanoid_real.xml   # 18 bodies, 17 actuators, ~0.72 m tall, 1.30 kg
+  # v2 (build_humanoid_mjcf.py): 18 bodies, 17 actuators, ~0.72 m, 1.30 kg.
+  # POSITION servos (ctrl = target joint ANGLE, not torque) at real BOM torque
+  # limits (SCS15 1.47 N*m legs/waist, SCS0009 0.226 N*m arms); capsule/box
+  # collision with self-collision on; inertia grounded in mesh geometry; home
+  # keyframe = solved balanced standing pose. Passes 13/13 test_model_integrity.
+  # (v1 models/humanoid_real.xml — torque motors — still on disk if needed.)
+  xml_file: models/humanoid_real_v2.xml
 
   seed: 42
   n_envs: 12
@@ -16,31 +22,69 @@ standing:
   max_episode_steps: 5000              # shorter than std (10000): smaller robot, faster dynamics
 
   # ========== OBSERVATION PROCESSING ==========
-  # Real-robot obs dim is 460 (vs std 365). With history×4 + COM(6): 1864.
-  # The standing_env introspection handles the dim difference automatically.
+  # DEPLOYABLE (proprioceptive) observation. The stock Humanoid-v5 obs is ~460
+  # dims, ~400 of which (cinert/cvel/cfrc_ext/COM) are privileged sim state with
+  # no real sensor — a policy trained on it cannot run on hardware. With
+  # proprioceptive_obs the env rebuilds the obs from measurable-only signals:
+  #   proj_grav(3) + base_ang_vel(3) + joint_pos(17) + joint_vel(17)
+  #   + last_action(17) = 57, x history(4) = 228 dims.
+  # Every term maps 1:1 to a sensor on the robot (IMU quat -> proj_grav,
+  # IMU gyro -> ang_vel, encoders -> joint_pos/vel). NOTE: this changes the obs
+  # dim, so it is NOT checkpoint-compatible with the old 1864 privileged runs.
+  proprioceptive_obs: true
+  obs_foot_contact: false   # FSRs not wired yet; enable once they're on A0/A1
   obs_history: 4
-  obs_include_com: true
-  obs_feature_norm: true
+  obs_include_com: false    # forced off in proprioceptive mode (COM not measurable)
+  obs_feature_norm: false   # let VecNormalize scale; tanh(0.1x) over-squashes proprio obs
 
   # ========== ACTION ==========
   action_smoothing: true
-  action_smoothing_tau: 0.5
+  # 6/16: lowered 0.5 -> 0.3 for sim2real jitter. A tau=0.3 inference probe cut
+  # target chatter -47% (5.2->2.8 deg/step) but the tau=0.5-trained policy fell
+  # (3597<5000). Bumping action_rate_penalty alone (2->15) barely moved jitter
+  # (-13%) because it's dwarfed by the +300 sustained bonus -> tau is the real
+  # lever. Fine-tune AT 0.3 so the policy re-learns balance under the smoothing.
+  # NOTE: deployment inference loop must EMA-smooth actions at this same tau.
+  action_smoothing_tau: 0.3
   action_symmetry: false
   pd_assist: false
+  # Anti-jitter: penalize ||a_t - a_{t-1}||^2 of the applied target. The v1 run
+  # had no such term + std pinned at the cap, so the deterministic policy shook
+  # ("taut string"). Start moderate; raise if still twitchy, lower if it won't
+  # balance. Penalty is internally capped at -20.
+  # 6/16: bumped 2.0 -> 15.0 for sim2real. At 2.0 the term was ~-0.2 vs ~375
+  # reward (~0.05%) so the policy had no smoothness incentive: measured ~4-5 Hz
+  # tremor, 5.2 deg RMS target-change/step (scripts/debug/measure_jitter.py).
+  # A tau=0.3 inference probe halved the chatter but fell (3597<5000) -> must
+  # fine-tune so the policy re-learns balance under a smoothness gradient.
+  action_rate_penalty: 15.0
+  # Yaw-rate damping (anti-spin). The proprioceptive obs is yaw-INVARIANT
+  # (projected gravity can't see heading), so the policy drifts in a slow
+  # in-place spin. Yaw RATE is observable (gyro / qvel[5]), so penalize its
+  # square to null the spin. Penalty internally capped at -10. 0.0 = off.
+  yaw_rate_penalty: 30.0
 
   # ========== CURRICULUM ==========
   # Targets stay in the legacy 1.40-regime; _get_height() returns scaled COM-z
   # for custom models, so [0.80..1.40] maps to real COM [0.30..0.53] m.
-  curriculum_start_stage: 0
+  # Custom-model height scaling maps the robot's NATURAL standing COM to 1.40 —
+  # the curriculum's FINAL target. So the reset pose already sits at the goal and
+  # stages 0-4 (crouch heights 0.80-1.35) are vestigial: the v1 run froze at
+  # stage 0 forever (err locked at |1.40-0.80|=0.600) while the robot stood fine
+  # at 1.40. Start at the final stage so the run trains the real target.
+  curriculum_start_stage: 5
   curriculum_max_stage: 5
   curriculum_advance_after: 20
   curriculum_success_rate: 0.60
 
   # ========== DOMAIN RANDOMIZATION ==========
-  # Off initially. The Fusion-exported masses are validated against the real
-  # 3 lb robot but the inertias are Fusion defaults — enable rand only after
-  # the base controller is stable, so we know the unrandomized model trains.
+  # Off initially. Masses are real (Fusion densities, 1.30 kg) and inertias are
+  # now geometry-grounded (v2 reground_inertia), so the unrandomized model is
+  # physically faithful — enable rand only after the base controller is stable.
   domain_rand: false
+  # The 6-stage curriculum normally force-enables domain_rand at the final stage.
+  # Opt out so our explicit domain_rand:false above is honored even at stage 5.
+  curriculum_manage_domain_rand: false
   rand_mass_range: [0.97, 1.03]
   rand_friction_range: [0.97, 1.03]
 
@@ -56,13 +100,18 @@ standing:
     termination_penalty_constant: 50.0
 
   # ========== PPO HYPERPARAMETERS ==========
-  total_timesteps: 5_000_000
+  total_timesteps: 10_000_000   # 2x: real body needs more steps to converge from scratch
   learning_rate: 0.0003
   final_learning_rate: 0.00005
 
   n_steps: 2048
-  batch_size: 256
-  n_epochs: 10
+  # KL-stability fix for the real body. The std config's 256/10 (=960 grad
+  # steps/cycle) KL-explodes here (clip_fraction 0.755, KL 0.31) because the
+  # lighter real body is more update-sensitive. 2048/5 = 60 grad steps/cycle:
+  # ~16x gentler, still enough to learn from scratch (cf. walking b91a244 which
+  # uses full-batch 24576/3 for the same reason).
+  batch_size: 2048
+  n_epochs: 5
 
   gamma: 0.995
   gae_lambda: 0.95
@@ -70,8 +119,18 @@ standing:
   clip_range: 0.2
   final_clip_range: 0.1
 
-  ent_coef: 0.02
-  final_ent_coef: 0.005
+  ent_coef: 0.005        # was 0.02; that pushed std hard against the log_std cap. Lower so the
+                         #   policy is free to sharpen its mean instead of maximizing noise.
+  final_ent_coef: 0.001   # lower: let std tighten instead of staying pinned at the log_std cap
+
+  # log_std clamp. CRITICAL for the v2 position-servo plant: action = target joint angle
+  # in RADIANS (ranges ~+-1.5 rad), NOT a torque on [-1,1]. v1 capped at 0.0 (std<=1.0)
+  # which is ~1 rad / ~57 deg of action noise per joint -> violent jitter, and the
+  # deterministic mean was never a stable balance point (fell ~step 120, 0% eval success).
+  # Clamp into a tight band: [-2.0, -1.5] => std in [0.135, 0.223] rad (~8-13 deg). Always
+  # some exploration, never the ~1 rad noise that destabilized the noise-free policy.
+  log_std_max: -1.5
+  log_std_min: -2.0
 
   vf_coef: 0.5
   max_grad_norm: 0.5

--- a/scripts/debug/measure_jitter.py
+++ b/scripts/debug/measure_jitter.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# measure_jitter.py
+"""
+Quantify standing-policy jitter for sim-to-real readiness.
+
+Runs ONE deterministic episode and measures, per joint:
+  - RMS joint speed (rad/s, deg/s)      -> how much each joint moves
+  - velocity reversal rate              -> fraction of control steps where the
+                                           joint velocity flips sign; ~0 = smooth,
+                                           high = buzzing/chatter (the jitter)
+  - effective jitter frequency (Hz)     -> reversal_rate * control_hz / 2
+  - applied target step delta (RMS)     -> change in the post-smoothing servo
+                                           target each control step (rad)
+
+Mirrors scripts/evaluate.py env construction exactly (same VecNormalize, same
+deterministic action) so the numbers correspond to what the recorded video shows.
+
+Usage:
+  python scripts/debug/measure_jitter.py --task standing \
+    --model models/final_real_standing_model.zip \
+    --vecnorm models/vecnorm_real_standing.pkl \
+    --config config/real_humanoid_config.yaml --max-steps 5000
+"""
+
+import os
+import sys
+import argparse
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+import numpy as np
+import yaml
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+
+
+def make_eval_env(task, config):
+    if task == "standing":
+        from src.environments import make_standing_env
+        return make_standing_env(render_mode=None, config=config)
+    elif task == "walking":
+        from src.environments import make_walking_env
+        return make_walking_env(render_mode=None, config=config)
+    raise ValueError(task)
+
+
+def find_wrapper_with(attr, env):
+    """Walk the gym wrapper chain to find the object exposing `attr`."""
+    cur = env
+    for _ in range(20):
+        if hasattr(cur, attr):
+            return cur
+        if hasattr(cur, "env"):
+            cur = cur.env
+        else:
+            break
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--task", default="standing", choices=["standing", "walking"])
+    p.add_argument("--model", required=True)
+    p.add_argument("--vecnorm", default=None)
+    p.add_argument("--config", required=True)
+    p.add_argument("--max-steps", type=int, default=5000)
+    p.add_argument("--tau", type=float, default=None,
+                   help="Override action_smoothing_tau (inference smoothing probe)")
+    args = p.parse_args()
+
+    with open(args.config) as f:
+        full = yaml.safe_load(f)
+    config = full.get(args.task, full)
+    if args.tau is not None:
+        config = dict(config)
+        config["action_smoothing"] = True
+        config["action_smoothing_tau"] = args.tau
+        print(f">>> OVERRIDE action_smoothing_tau = {args.tau}")
+
+    env = make_eval_env(args.task, config)
+    vec = DummyVecEnv([lambda: env])
+    if args.vecnorm and os.path.exists(args.vecnorm):
+        vec = VecNormalize.load(args.vecnorm, vec)
+        vec.training = False
+        vec.norm_reward = False
+
+    model = PPO.load(args.model, env=vec)
+
+    inner = vec.venv.envs[0]
+    base = inner.unwrapped                       # MujocoEnv (qpos/qvel/data)
+    wrap = find_wrapper_with("_last_action_rate", inner)  # StandingEnv wrapper
+    nj = int(getattr(wrap, "n_joints", 17))
+    control_hz = 1.0 / float(base.dt)
+
+    # actuator names for human-readable mapping
+    try:
+        act_names = [base.model.actuator(i).name for i in range(base.model.nu)]
+    except Exception:
+        act_names = [f"act{i}" for i in range(nj)]
+
+    obs = vec.reset()
+    jvel_hist = []      # joint velocities (rad/s) each step
+    adelta_hist = []    # applied-target step delta (rad) each step
+
+    for step in range(args.max_steps):
+        action, _ = model.predict(obs, deterministic=True)
+        obs, reward, done, info = vec.step(action)
+        jvel_hist.append(np.asarray(base.data.qvel[6:6 + nj], dtype=np.float64).copy())
+        if wrap is not None:
+            adelta_hist.append(np.asarray(wrap._last_action_rate, dtype=np.float64).ravel().copy())
+        if done[0]:
+            break
+
+    jvel = np.array(jvel_hist)            # (T, nj)
+    T = jvel.shape[0]
+    adelta = np.array(adelta_hist) if adelta_hist else None
+
+    rms_speed = np.sqrt(np.mean(jvel ** 2, axis=0))        # rad/s per joint
+    max_speed = np.max(np.abs(jvel), axis=0)
+    # reversal rate: sign change of velocity between consecutive steps
+    sign = np.sign(jvel)
+    reversals = np.mean(sign[1:] * sign[:-1] < 0, axis=0)  # fraction of steps
+    jit_hz = reversals * control_hz / 2.0
+    rms_adelta = (np.sqrt(np.mean(adelta ** 2, axis=0)) if adelta is not None
+                  else np.zeros(nj))
+
+    print(f"\n{'='*78}")
+    print(f"JITTER DIAGNOSTIC  ({T} steps, control {control_hz:.1f} Hz, dt={base.dt:.4f}s)")
+    print(f"{'='*78}")
+    print("Per joint, sorted by reversal rate (jitter signature):\n")
+    print(f"{'joint(actuator)':<20} {'RMSspeed':>9} {'RMSspeed':>9} {'maxspeed':>9} "
+          f"{'reversal':>9} {'jit~Hz':>7} {'RMSdΔtgt':>9}")
+    print(f"{'':<20} {'rad/s':>9} {'deg/s':>9} {'deg/s':>9} "
+          f"{'rate':>9} {'':>7} {'rad':>9}")
+    print("-" * 78)
+    order = np.argsort(-reversals)
+    for j in order:
+        name = act_names[j] if j < len(act_names) else f"j{j}"
+        print(f"{j:>2} {name:<16} {rms_speed[j]:>9.3f} {np.degrees(rms_speed[j]):>9.1f} "
+              f"{np.degrees(max_speed[j]):>9.1f} {reversals[j]:>9.2f} {jit_hz[j]:>7.1f} "
+              f"{rms_adelta[j]:>9.4f}")
+    print("-" * 78)
+    print(f"{'AGGREGATE':<20} {np.sqrt(np.mean(rms_speed**2)):>9.3f} "
+          f"{np.degrees(np.sqrt(np.mean(rms_speed**2))):>9.1f} "
+          f"{np.degrees(np.max(max_speed)):>9.1f} {np.mean(reversals):>9.2f} "
+          f"{np.mean(jit_hz):>7.1f} {np.sqrt(np.mean(rms_adelta**2)):>9.4f}")
+    print(f"{'='*78}")
+    print("Read: reversal rate ~0.0 = smooth; >0.3 = oscillating; ~0.5+ = step-rate buzz.")
+    print("RMSdΔtgt = RMS change in applied servo target per control step (radians).")
+
+    vec.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_standing.py
+++ b/scripts/train_standing.py
@@ -300,7 +300,10 @@ def main():
 
     callbacks = CallbackList([
         EntropyScheduleCallback(initial_ent, final_ent, learn_timesteps, verbose=1),
-        LogStdClampCallback(log_std_min=-2.0, log_std_max=0.5, clamp_freq=500, verbose=1),
+        LogStdClampCallback(
+            log_std_min=float(standing.get('log_std_min', -2.0)),
+            log_std_max=float(standing.get('log_std_max', 0.5)),
+            clamp_freq=500, verbose=1),
         SaveVecNormCallback(vecnorm_path, freq=int(standing.get('save_freq', 100_000))),
         JsonlMetricsCallback(
             output_path=metrics_path,

--- a/src/environments/standing_curriculum.py
+++ b/src/environments/standing_curriculum.py
@@ -50,6 +50,12 @@ class StandingCurriculumEnv(StandingEnv):
 
     def _apply_stage_settings(self, cfg: Dict[str, Any], stage: int) -> None:
         """Configure curriculum stage with progressive difficulty."""
+        # The per-stage logic below escalates domain randomization (off early,
+        # full at the final stage). Set curriculum_manage_domain_rand: false to
+        # opt out and keep the config's explicit domain_rand value — needed for
+        # the real-robot first run, which wants rand OFF even at stage 5.
+        manage_domain_rand = cfg.get('curriculum_manage_domain_rand', True)
+        user_domain_rand = cfg.get('domain_rand', False)
         if stage == 0:
             # Stage 0 (0.80m): Recovery training, very forgiving
             cfg['domain_rand'] = False
@@ -78,6 +84,11 @@ class StandingCurriculumEnv(StandingEnv):
             cfg['max_episode_steps'] = 5000
             cfg['random_height_init'] = True
             cfg['random_height_prob'] = 0.1  # Still some random init for robustness
+
+        # Honor an explicit opt-out: leave domain_rand at the config's value
+        # instead of the stage-escalated one.
+        if not manage_domain_rand:
+            cfg['domain_rand'] = user_domain_rand
 
     def reset(self, seed: Optional[int] = None):
         # Update target height for current stage

--- a/src/environments/standing_env.py
+++ b/src/environments/standing_env.py
@@ -62,6 +62,10 @@ class StandingEnv(gym.Wrapper):
         self.domain_rand = self.cfg.get('domain_rand', False)
         self.rand_mass_range = self.cfg.get('rand_mass_range', [0.95, 1.05])
         self.rand_friction_range = self.cfg.get('rand_friction_range', [0.95, 1.05])
+        # Nominal model params, captured lazily on first domain-rand reset so
+        # randomization is applied relative to nominal (not compounded).
+        self._nominal_body_mass = None
+        self._nominal_geom_friction = None
         
         #Random height initialization for recovery training
         self.random_height_init = self.cfg.get('random_height_init', True)
@@ -88,6 +92,18 @@ class StandingEnv(gym.Wrapper):
         self.pd_kp = float(self.cfg.get('pd_kp', 0.0))
         self.pd_kd = float(self.cfg.get('pd_kd', 0.0))
         self.prev_action = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        # Action-rate penalty: discourage high-frequency setpoint jitter (the
+        # "taut string" shake). Penalizes ||a_t - a_{t-1}||^2 of the applied
+        # (smoothed) action. 0.0 = off, so the legacy std-humanoid path is
+        # byte-identical.
+        self.action_rate_weight = float(self.cfg.get('action_rate_penalty', 0.0))
+        self._last_action_rate = np.zeros(self.env.action_space.shape, dtype=np.float32)
+
+        # Yaw-rate damping. Penalizes (base yaw rate)^2 to discourage the slow
+        # in-place spin that proprioceptive obs can't correct via heading
+        # (projected gravity is yaw-invariant) but CAN sense via the gyro
+        # (qvel[5] / base_ang_vel). 0.0 = off (legacy std path byte-identical).
+        self.yaw_rate_weight = float(self.cfg.get('yaw_rate_penalty', 0.0))
 
         # Observation processing
         self.enable_history = int(self.cfg.get('obs_history', 0)) > 0
@@ -95,17 +111,46 @@ class StandingEnv(gym.Wrapper):
         self.obs_history = []
         self.include_com = bool(self.cfg.get('obs_include_com', False))
         self.feature_norm = bool(self.cfg.get('obs_feature_norm', False))
-        
+
+        # ----- Proprioceptive (deployable) observation -----
+        # When True, the observation is rebuilt from ONLY quantities a real robot
+        # can measure: base orientation -> projected gravity (IMU), base angular
+        # velocity (gyro), joint positions (encoders), joint velocities, and the
+        # last applied action. This replaces Humanoid-v5's stock obs, ~400 dims of
+        # which (cinert/cvel/cfrc_ext/COM) are privileged sim state with no real
+        # sensor. Default False keeps the legacy privileged obs byte-identical.
+        self.proprioceptive = bool(self.cfg.get('proprioceptive_obs', False))
+        self.include_foot_contact = bool(self.cfg.get('obs_foot_contact', False))
+        if self.proprioceptive:
+            # COM (subtree_com) is not measurable on hardware -> never include it.
+            self.include_com = False
+        # Nominal (home-keyframe) joint pose. Proprioceptive joint obs is reported
+        # RELATIVE to this, matching the real robot's encoder-minus-home convention
+        # (the v2 home keyframe is a bent standing pose, not all-zeros).
+        m_unwrapped = self.env.unwrapped.model
+        self.n_joints = int(m_unwrapped.nu)
+        if m_unwrapped.nkey > 0:
+            self.default_joint_pos = np.asarray(
+                m_unwrapped.key_qpos[0][7:7 + self.n_joints], dtype=np.float32
+            )
+        else:
+            self.default_joint_pos = np.zeros(self.n_joints, dtype=np.float32)
+
         # Humanoid-v5 reports a smaller observation_space than it actually
         # returns (the +15 below is the historical correction for the default
         # capsule model). Custom MJCFs don't have this discrepancy — measure
         # the actual stepped obs dim instead of trusting the magic number.
         base_obs_from_space = int(env.observation_space.shape[0])
-        if self._is_custom:
+        if self.proprioceptive:
+            # proj_grav(3) + base_ang_vel(3) + joint_pos(nj) + joint_vel(nj) + last_action(nj)
+            base_obs_dim = 6 + 3 * self.n_joints
+            if self.include_foot_contact:
+                base_obs_dim += 2  # per-foot contact booleans (FSR)
+        elif self._is_custom:
             base_obs_dim = self.model_spec.actual_obs_dim
         else:
             base_obs_dim = base_obs_from_space + 15  # Actual observations are 365 dims
-        
+
         # Calculate dimension after all processing steps
         extra_dim = 6 if self.include_com else 0  # COM pos (3) + COM vel (3)
         feature_dim = base_obs_dim + extra_dim
@@ -128,6 +173,11 @@ class StandingEnv(gym.Wrapper):
         )
         
         print("Observation space configuration:")
+        if self.proprioceptive:
+            print(f"  PROPRIOCEPTIVE (deployable) obs: "
+                  f"proj_grav(3)+ang_vel(3)+jpos({self.n_joints})+jvel({self.n_joints})"
+                  f"+last_action({self.n_joints})"
+                  f"{'+foot_contact(2)' if self.include_foot_contact else ''} = {base_obs_dim}")
         print(f"  Base from env.observation_space: {base_obs_from_space}")
         print(f"  + Position inclusion adjustment: +15 -> {base_obs_dim}")
         print(f"  + COM features: {extra_dim} -> {feature_dim}")
@@ -163,6 +213,7 @@ class StandingEnv(gym.Wrapper):
         self.prev_height = default_height
         self.target_height = self.base_target_height
         self.prev_action[:] = 0.0
+        self._last_action_rate[:] = 0.0
         self.obs_history = []  # Clear history
         
         # Clear reward history
@@ -170,16 +221,21 @@ class StandingEnv(gym.Wrapper):
             self.reward_history[key] = []
         
         if self.domain_rand:
-            # Randomize body masses
-            self.env.unwrapped.model.body_mass *= np.random.uniform(
+            m = self.env.unwrapped.model
+            # Capture nominal params once, then randomize RELATIVE to nominal every
+            # reset. The old code multiplied the live arrays in place, so the
+            # randomization compounded across episodes and mass/friction drifted
+            # away over a long run.
+            if self._nominal_body_mass is None:
+                self._nominal_body_mass = m.body_mass.copy()
+                self._nominal_geom_friction = m.geom_friction.copy()
+            m.body_mass[:] = self._nominal_body_mass * np.random.uniform(
                 self.rand_mass_range[0], self.rand_mass_range[1],
-                size=self.env.unwrapped.model.body_mass.shape
+                size=m.body_mass.shape
             )
-
-            # Randomize geom friction
-            self.env.unwrapped.model.geom_friction[:, 0] *= np.random.uniform(
+            m.geom_friction[:, 0] = self._nominal_geom_friction[:, 0] * np.random.uniform(
                 self.rand_friction_range[0], self.rand_friction_range[1],
-                size=self.env.unwrapped.model.geom_friction.shape[0]
+                size=m.geom_friction.shape[0]
             )
         
         # Random height initialization for recovery training. Skip for custom
@@ -201,14 +257,18 @@ class StandingEnv(gym.Wrapper):
             observation = self.env.unwrapped._get_obs()
         
         # Process observation with guaranteed dimension
-        if self.enable_history or self.include_com or self.feature_norm:
+        if self.enable_history or self.include_com or self.feature_norm or self.proprioceptive:
             observation = self._process_observation(observation)
 
         return observation, info
     
     def step(self, action):
-        # Action preprocessing
+        # Action preprocessing. Capture the previously-applied (smoothed) action
+        # before _process_action overwrites prev_action, so the reward can charge
+        # the per-step action rate.
+        prev_applied = self.prev_action.copy()
         proc_action = self._process_action(np.asarray(action, dtype=np.float32))
+        self._last_action_rate = proc_action - prev_applied
 
         observation, base_reward, terminated, truncated, info = self.env.step(proc_action)
         self.current_step += 1
@@ -223,7 +283,7 @@ class StandingEnv(gym.Wrapper):
         info.update(self._get_task_info())
         
         # Process observation with dimension verification
-        if self.enable_history or self.include_com or self.feature_norm:
+        if self.enable_history or self.include_com or self.feature_norm or self.proprioceptive:
             observation = self._process_observation(observation)
 
         return observation, reward, terminated, truncated, info
@@ -260,7 +320,12 @@ class StandingEnv(gym.Wrapper):
             height_reward = 25.0 - 20.0 * np.clip((height - 1.6) / 0.2, 0.0, 1.0)  
         
         # ========== UPRIGHT ORIENTATION REWARD  ==========
-        upright_error = 1.0 - abs(quat[0])
+        # Yaw-invariant tilt from projected gravity: gz = -1 upright, 0 horizontal.
+        # upright_cos = +1 upright, 0 horizontal, -1 inverted. (quat_w was WRONG
+        # here: a pure yaw spin shrinks quat_w and falsely reads as tipping.)
+        proj_grav = self._projected_gravity(quat)
+        upright_cos = -float(proj_grav[2])
+        upright_error = 1.0 - upright_cos
         if height >= 1.2:
             upright_reward = 12.0 * np.exp(-8.0 * upright_error**2)  
         elif height >= 1.0:
@@ -285,7 +350,29 @@ class StandingEnv(gym.Wrapper):
         
         # ========== CONTROL COST ========== 
         control_cost = -0.005 * np.sum(np.square(action))
-        
+
+        # ==========  ACTION-RATE PENALTY (anti-jitter / sim2real smoothness) ==========
+        # Charge the squared per-step change in the applied target. Capped so a
+        # single transient can't spike PPO's value targets.
+        if self.action_rate_weight > 0.0:
+            action_rate_penalty = -min(
+                self.action_rate_weight * float(np.sum(np.square(self._last_action_rate))),
+                20.0,
+            )
+        else:
+            action_rate_penalty = 0.0
+
+        # ==========  YAW-RATE DAMPING (anti-spin) ==========
+        # angular_vel = qvel[3:6] (base frame); [2] is yaw rate. Penalize its
+        # square, capped, so a transient can't spike PPO value targets.
+        if self.yaw_rate_weight > 0.0:
+            yaw_rate_penalty = -min(
+                self.yaw_rate_weight * float(angular_vel[2]) ** 2,
+                10.0,
+            )
+        else:
+            yaw_rate_penalty = 0.0
+
         # ==========  CAPPED HEIGHT MAINTENANCE PENALTY ==========
         height_velocity = height - self.prev_height if hasattr(self, 'prev_height') else 0.0
         if height_velocity < -0.003:  # Losing height
@@ -330,17 +417,19 @@ class StandingEnv(gym.Wrapper):
         termination_penalty = 0.0
         
         # ========== TERMINATION CONDITIONS ==========
+        # Tip-over test uses yaw-invariant tilt (upright_cos < 0.5 ~= >60 deg
+        # tilt), NOT quat_w (which fired at ~106 deg of harmless yaw).
         terminate = (
             height < 0.75 or
             height > 2.0 or
-            abs(quat[0]) < 0.6
+            upright_cos < 0.5
         )
-        
+
         #  Apply CONSTANT termination penalty (not time-dependent)
         if terminate:
             if height < 0.75:  # Fell too low
                 termination_penalty = -self.termination_penalty_constant
-            elif abs(quat[0]) < 0.6:  # Tipped over
+            elif upright_cos < 0.5:  # Tipped over
                 termination_penalty = -self.termination_penalty_constant
             else:  # Other terminations (height too high)
                 termination_penalty = -self.termination_penalty_constant * 0.5
@@ -353,9 +442,11 @@ class StandingEnv(gym.Wrapper):
             smoothness_reward +
             control_cost +
             height_maintenance +
-            recovery_bonus +  
+            recovery_bonus +
             velocity_penalty +
             sustained_bonus +
+            action_rate_penalty +
+            yaw_rate_penalty +
             termination_penalty
         )
         
@@ -372,10 +463,11 @@ class StandingEnv(gym.Wrapper):
         if self.current_step % 500 == 0:
             print(f"Step {self.current_step:4d}: "
                 f"h={height:.3f} (err={height_error:.3f}), "
-                f"quat_w={quat[0]:.3f}, "
+                f"tilt_cos={upright_cos:.3f}, yaw_rate={float(angular_vel[2]):+.2f}, "
                 f"r={total_reward:6.1f} "
                 f"[h={height_reward:6.1f}, u={upright_reward:4.1f}, "
                 f"stab={stability_reward:4.1f}, recov={recovery_bonus:4.1f}, "
+                f"rate={action_rate_penalty:5.1f}, yaw={yaw_rate_penalty:5.1f}, "
                 f"bonus={sustained_bonus:.0f}]")
         
         return total_reward, terminate
@@ -413,20 +505,25 @@ class StandingEnv(gym.Wrapper):
 
     def _process_observation(self, obs: np.ndarray) -> np.ndarray:
         """Process observation with correct dimension handling."""
-        features = [obs]
+        if self.proprioceptive:
+            # Rebuild obs from measurable-only signals; ignore the privileged
+            # Humanoid-v5 obs entirely.
+            feat_vec = self._proprioceptive_features()
+        else:
+            features = [obs]
 
-        # Add COM features if enabled
-        if self.include_com:
-            try:
-                com_pos = self.env.unwrapped.data.subtree_com[0]
-                com_vel = self.env.unwrapped.data.cdof_dot[:3] if hasattr(self.env.unwrapped.data, 'cdof_dot') else self.env.unwrapped.data.qvel[:3]
-                features.append(np.asarray(com_pos, dtype=np.float32))
-                features.append(np.asarray(com_vel, dtype=np.float32))
-            except (AttributeError, IndexError) as e:
-                logger.warning("Failed to add COM features: %s", e)
+            # Add COM features if enabled
+            if self.include_com:
+                try:
+                    com_pos = self.env.unwrapped.data.subtree_com[0]
+                    com_vel = self.env.unwrapped.data.cdof_dot[:3] if hasattr(self.env.unwrapped.data, 'cdof_dot') else self.env.unwrapped.data.qvel[:3]
+                    features.append(np.asarray(com_pos, dtype=np.float32))
+                    features.append(np.asarray(com_vel, dtype=np.float32))
+                except (AttributeError, IndexError) as e:
+                    logger.warning("Failed to add COM features: %s", e)
 
-        # Concatenate base + COM features
-        feat_vec = np.concatenate([np.atleast_1d(f).ravel() for f in features]).astype(np.float32)
+            # Concatenate base + COM features
+            feat_vec = np.concatenate([np.atleast_1d(f).ravel() for f in features]).astype(np.float32)
 
         # Feature normalization
         if self.feature_norm:
@@ -459,7 +556,68 @@ class StandingEnv(gym.Wrapper):
                 feat_vec = np.concatenate([feat_vec, pad], axis=0)
 
         return feat_vec
-        
+
+    # ======== Proprioceptive (deployable) observation ========
+
+    @staticmethod
+    def _projected_gravity(quat: np.ndarray) -> np.ndarray:
+        """Gravity direction expressed in the base body frame.
+
+        World gravity points down ([0,0,-1]); rotating it into the base frame by
+        the root orientation gives a 3-vector that is [0,0,-1] when upright and
+        tilts as the torso tips. This is the standard sim2real orientation cue and
+        is reconstructed on hardware from the IMU's fused orientation.
+
+        quat is MuJoCo order [w, x, y, z].
+        Convention check: real IMU accel at rest reads +1g UP, i.e. specific
+        force = -projected_gravity. Deployment should feed -accel_normalized here.
+        """
+        w, x, y, z = float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3])
+        gx = 2.0 * (w * y - x * z)
+        gy = -2.0 * (y * z + w * x)
+        gz = 2.0 * (x * x + y * y) - 1.0
+        return np.array([gx, gy, gz], dtype=np.float32)
+
+    def _foot_contacts(self) -> np.ndarray:
+        """Per-foot contact booleans — the signal the FSRs will provide.
+
+        Derived in sim from the foot bodies' external contact force magnitude.
+        Defaults off; only used when obs_foot_contact is set.
+        """
+        data = self.env.unwrapped.data
+        ids = self.model_spec.foot_body_ids if self._is_custom else []
+        out = []
+        for bid in list(ids)[:2]:
+            f = float(np.linalg.norm(data.cfrc_ext[bid][3:6]))
+            out.append(1.0 if f > 1.0 else 0.0)
+        while len(out) < 2:
+            out.append(0.0)
+        return np.asarray(out, dtype=np.float32)
+
+    def _proprioceptive_features(self) -> np.ndarray:
+        """Build the per-frame observation from measurable-only signals.
+
+        Order (must match deployment exactly):
+          projected_gravity(3) | base_ang_vel(3) | joint_pos-default(nj) |
+          joint_vel(nj) | last_action(nj) | [foot_contact(2)]
+        """
+        data = self.env.unwrapped.data
+        # base orientation -> projected gravity (IMU fused orientation on hardware)
+        proj_grav = self._projected_gravity(np.asarray(data.qpos[3:7]))
+        # base angular velocity, free-joint local frame (matches IMU gyro)
+        base_ang_vel = np.asarray(data.qvel[3:6], dtype=np.float32)
+        # joint angles relative to home pose (encoder-minus-home on hardware)
+        jpos = np.asarray(data.qpos[7:7 + self.n_joints], dtype=np.float32) - self.default_joint_pos
+        # joint velocities (finite-difference of encoders on hardware)
+        jvel = np.asarray(data.qvel[6:6 + self.n_joints], dtype=np.float32)
+        # last applied (smoothed) action
+        last_action = np.asarray(self.prev_action, dtype=np.float32).ravel()
+
+        feats = [proj_grav, base_ang_vel, jpos, jvel, last_action]
+        if self.include_foot_contact:
+            feats.append(self._foot_contacts())
+        return np.concatenate([np.atleast_1d(f).ravel() for f in feats]).astype(np.float32)
+
     def _get_task_info(self):
         """Get task-specific information"""
         root_x, root_y = self.env.unwrapped.data.qpos[0:2]


### PR DESCRIPTION
Makes the real-humanoid standing policy **deployable**: a sensor-only observation, a correctness fix to the upright metric, and a jitter reduction for sim-to-real.

## Changes
**`standing_env.py`**
- **Proprioceptive obs** (`proprioceptive_obs`): rebuilds the observation from measurable-only signals — `proj_grav(3) | base_ang_vel(3) | jpos−home(17) | jvel(17) | last_action(17)` ×4 history = **228 dims**, replacing the 1864-dim privileged obs (~400 dims of cinert/cvel/cfrc/COM with no hardware sensor).
- **Yaw fix**: upright reward + tip-over termination now use yaw-invariant projected-gravity tilt (`upright_cos = -proj_grav[2]`) instead of `quat_w`, which conflated a harmless in-place yaw spin with tipping (reported false "0% success"). Adds a gyro-observable yaw-rate damping reward.
- **`action_rate_penalty`** term for action smoothness.

**`standing_curriculum.py`** — `curriculum_manage_domain_rand` flag so stage 5 doesn't force-enable domain randomization when the config wants it off.

**`config/real_humanoid_config.yaml`** — deployable recipe: `humanoid_real_v2.xml`, `proprioceptive_obs: true`, `action_smoothing_tau: 0.3`, `action_rate_penalty: 15`, `yaw_rate_penalty: 30`.

**`scripts/debug/measure_jitter.py`** — per-joint RMS speed / velocity-reversal-rate / applied-target step-delta diagnostic (with a `--tau` inference probe).

## Result
20/20 deterministic eval @ 5000 steps, height locked 1.400; jitter cut ~56% (5.2 → 2.3°/step target chatter) while balance went to 100%.

> Depends on `humanoid_real_v2.xml` from the model-assets PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)