### PR TITLE
Torch-free NumPy policy export for lightweight Pi inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,7 @@ models/configs/*.yaml
 models/*.zip
 models/*.pkl
 
+# Exported NumPy policy bundles (deploy artifact; scp to the Pi, like the .zip/.pkl)
+models/**/*.npz
+models/*.npz
+

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -10,6 +10,24 @@ All files here run **on the Pi** except the `--dry-run` paths, which run anywher
 | `hardware.py` | **The hardware seam.** `ServoBus` (scservo_sdk SCSCL) + `IMU` (ICM-20948). Reconcile with your Pi driver HERE only. |
 | `verify_signs.py` | Bench tool: confirm which servo each action index drives and its sign. Writes results back into the map. |
 | `deploy_standing.py` | The closed-loop inference loop. |
+| `export_policy.py` | **Dev box only:** dump the SB3 policy + vecnorm stats to a torch-free `.npz`. |
+| `numpy_policy.py` | Pure-NumPy inference for the `.npz` (no torch/SB3/pickle). |
+
+## Recommended: torch-free NumPy policy
+Running torch + SB3 on a Pi works but the ARM wheels are heavy/fiddly. The policy is a small
+`[512,512,256]` SiLU MLP, so export it to a NumPy bundle and the Pi needs only `numpy` + `pyyaml`:
+
+```bash
+# on the DEV box (has torch+SB3):
+python scripts/deploy/export_policy.py        # -> models/real_standing_policy.npz (~2 MB)
+#   bundles policy weights AND vecnorm stats; self-checks parity vs SB3 (asserts <1e-4).
+# scp models/real_standing_policy.npz pi@<ip>:~/humanoidnavigation/models/
+
+# on the Pi:
+python scripts/deploy/deploy_standing.py --policy-npz models/real_standing_policy.npz
+```
+Output is byte-identical to the SB3 backend. Without `--policy-npz`, the loop falls back to
+loading the `.zip` + `.pkl` (needs torch+SB3). The `.npz` is gitignored — `scp` it like the `.zip`/`.pkl`.
 
 ## Order of operations
 1. **Validate wiring (any machine):** `python scripts/deploy/deploy_standing.py --dry-run`

--- a/scripts/deploy/deploy_standing.py
+++ b/scripts/deploy/deploy_standing.py
@@ -55,6 +55,17 @@ def normalize(obs, mean, var, eps, clip):
     return np.clip((obs - mean) / np.sqrt(var + eps), -clip, clip).astype(np.float32)
 
 
+class _SB3Backend:
+    """Wraps an SB3 PPO model + vecnorm stats to a uniform predict(raw_obs)->action."""
+
+    def __init__(self, model, mean, var, eps, clip):
+        self.model, self.mean, self.var, self.eps, self.clip = model, mean, var, eps, clip
+
+    def predict(self, obs):
+        z = normalize(obs, self.mean, self.var, self.eps, self.clip)
+        return self.model.predict(z, deterministic=True)[0]
+
+
 class ObsBuilder:
     """Maintains history + finite-diff joint velocity, emits the 228-dim obs."""
 
@@ -86,6 +97,9 @@ def main():
     p.add_argument("--model", default=str(ROOT / "models" / "final_real_standing_model.zip"))
     p.add_argument("--vecnorm", default=str(ROOT / "models" / "vecnorm_real_standing.pkl"))
     p.add_argument("--map", default=str(DEFAULT_MAP))
+    p.add_argument("--policy-npz", default=None,
+                   help="torch-free NumPy policy bundle from export_policy.py. If set, runs with "
+                        "numpy only (no torch/SB3/pkl); else loads the SB3 .zip + vecnorm .pkl.")
     p.add_argument("--tau", type=float, default=0.3, help="action smoothing (MUST match training)")
     p.add_argument("--hz", type=float, default=40.0)
     p.add_argument("--ramp-secs", type=float, default=2.0, help="open-loop ramp to home before closed loop")
@@ -109,20 +123,26 @@ def main():
             return
         print(msg)
 
-    # ---- load policy + normalization ----
-    from stable_baselines3 import PPO  # noqa: E402
-    print(f"Loading model {args.model}")
-    model = PPO.load(args.model, device="cpu")
-    mean, var, eps, clip = load_vecnorm_stats(args.vecnorm)
-    print(f"VecNormalize stats OK (obs_dim={OBS_DIM}, clip={clip})")
+    # ---- load policy (numpy bundle OR torch/SB3) ----
+    if args.policy_npz:
+        from numpy_policy import NumpyPolicy  # noqa: E402
+        npol = NumpyPolicy.load(args.policy_npz)
+        assert npol.obs_dim == OBS_DIM, f"npz obs_dim {npol.obs_dim} != {OBS_DIM}"
+        infer = npol.predict  # raw obs -> action; normalization baked in
+        print(f"Policy: NumPy bundle {args.policy_npz} (no torch/SB3, obs_dim={npol.obs_dim})")
+    else:
+        from stable_baselines3 import PPO  # noqa: E402
+        model = PPO.load(args.model, device="cpu")
+        mean, var, eps, clip = load_vecnorm_stats(args.vecnorm)
+        infer = _SB3Backend(model, mean, var, eps, clip).predict
+        print(f"Policy: SB3 {args.model} + vecnorm (obs_dim={OBS_DIM}, clip={clip})")
 
     builder = ObsBuilder(m, dt)
 
     def predict_units(proj_grav, ang_vel, jpos):
         frame = builder.frame(proj_grav, ang_vel, jpos)
         obs = builder.obs(frame)
-        raw_action = model.predict(normalize(obs, mean, var, eps, clip), deterministic=True)[0]
-        raw_action = np.asarray(raw_action, dtype=np.float32).ravel()
+        raw_action = np.asarray(infer(obs), dtype=np.float32).ravel()
         # Match StandingEnv._process_action: SB3 clips the action to the space BEFORE the
         # env smooths it, so clip raw -> EMA-smooth -> clip again.
         raw_action = np.clip(raw_action, m.range_lo, m.range_hi)

--- a/scripts/deploy/export_policy.py
+++ b/scripts/deploy/export_policy.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# export_policy.py
+"""
+Export the SB3 PPO standing policy to a torch-free NumPy bundle (.npz) so the Pi can
+run inference with numpy only (no torch, no stable-baselines3, no pickle).
+
+Bundles BOTH the policy MLP weights AND the VecNormalize obs stats, so the single .npz
+is everything the deploy loop needs. The policy is a plain MLP with no output squashing
+(SB3 squash_output=False), so the deterministic action is just the final linear layer.
+
+Run on the DEV machine (needs torch+SB3), then scp the .npz to the Pi.
+
+  python scripts/deploy/export_policy.py        # -> models/real_standing_policy.npz
+"""
+
+from __future__ import annotations
+import argparse
+import pickle
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=str(ROOT / "models" / "final_real_standing_model.zip"))
+    p.add_argument("--vecnorm", default=str(ROOT / "models" / "vecnorm_real_standing.pkl"))
+    p.add_argument("--out", default=str(ROOT / "models" / "real_standing_policy.npz"))
+    args = p.parse_args()
+
+    import torch  # noqa: F401  (only needed here on the dev machine)
+    from stable_baselines3 import PPO
+
+    print(f"Loading {args.model}")
+    model = PPO.load(args.model, device="cpu")
+    pol = model.policy
+    assert pol.squash_output is False, "exporter assumes no output squashing"
+
+    # Extract the policy MLP (hidden Linear+SiLU stack) + the action mean head.
+    import torch.nn as nn
+    hidden = [m for m in pol.mlp_extractor.policy_net if isinstance(m, nn.Linear)]
+    out = pol.action_net
+    arrays = {"n_hidden": np.array(len(hidden), dtype=np.int64)}
+    for i, lin in enumerate(hidden):
+        arrays[f"h{i}_w"] = lin.weight.detach().cpu().numpy().astype(np.float32)
+        arrays[f"h{i}_b"] = lin.bias.detach().cpu().numpy().astype(np.float32)
+    arrays["out_w"] = out.weight.detach().cpu().numpy().astype(np.float32)
+    arrays["out_b"] = out.bias.detach().cpu().numpy().astype(np.float32)
+
+    # VecNormalize obs stats (so the Pi doesn't need the pkl / SB3).
+    with open(args.vecnorm, "rb") as f:
+        vn = pickle.load(f)
+    arrays["obs_mean"] = np.asarray(vn.obs_rms.mean, dtype=np.float32)
+    arrays["obs_var"] = np.asarray(vn.obs_rms.var, dtype=np.float32)
+    arrays["clip_obs"] = np.array(float(getattr(vn, "clip_obs", 10.0)), dtype=np.float32)
+    arrays["epsilon"] = np.array(float(getattr(vn, "epsilon", 1e-8)), dtype=np.float32)
+    obs_dim = arrays["obs_mean"].shape[0]
+    act_dim = arrays["out_b"].shape[0]
+
+    # ---- parity check: numpy forward vs SB3 deterministic, on normalized inputs ----
+    rng = np.random.default_rng(0)
+    z = rng.standard_normal((16, obs_dim)).astype(np.float32)
+
+    def np_forward(x):
+        for i in range(len(hidden)):
+            x = silu(x @ arrays[f"h{i}_w"].T + arrays[f"h{i}_b"])
+        return x @ arrays["out_w"].T + arrays["out_b"]
+
+    # Compare to SB3's UNCLIPPED Gaussian mean (the true weight-extraction check).
+    # model.predict() additionally clips to the action space; deploy_standing applies
+    # that same clip downstream, so validating the pre-clip mean is the right test.
+    with torch.no_grad():
+        dist = model.policy.get_distribution(torch.as_tensor(z))
+        sb3_mean = dist.distribution.mean.cpu().numpy()
+    np_act = np_forward(z)
+    max_err = float(np.max(np.abs(np_act - sb3_mean)))
+    print(f"parity max|numpy - sb3 mean| = {max_err:.2e}  (obs_dim={obs_dim}, act_dim={act_dim})")
+    assert max_err < 1e-4, f"parity check FAILED ({max_err:.2e}) — do not deploy this npz"
+
+    np.savez(args.out, **arrays)
+    sz = Path(args.out).stat().st_size / 1e6
+    print(f"OK: wrote {args.out} ({sz:.2f} MB). Parity verified. torch/SB3 not needed to run it.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy/numpy_policy.py
+++ b/scripts/deploy/numpy_policy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# numpy_policy.py
+"""
+Pure-NumPy inference for the standing policy. No torch, no stable-baselines3, no pickle.
+
+Loads the .npz produced by export_policy.py (policy MLP weights + VecNormalize stats) and
+runs the deterministic forward pass:  normalize(obs) -> [Linear+SiLU]*N -> Linear -> action.
+Owns its own obs normalization, so callers pass RAW (unnormalized) observations.
+"""
+
+from __future__ import annotations
+import numpy as np
+
+
+def silu(x):
+    return x / (1.0 + np.exp(-x))
+
+
+class NumpyPolicy:
+    def __init__(self, hidden, out_w, out_b, obs_mean, obs_var, clip_obs, epsilon):
+        self.hidden = hidden            # list of (W, b), W is (out,in)
+        self.out_w, self.out_b = out_w, out_b
+        self.obs_mean, self.obs_var = obs_mean, obs_var
+        self.clip_obs, self.epsilon = float(clip_obs), float(epsilon)
+        self.obs_dim = obs_mean.shape[0]
+        self.act_dim = out_b.shape[0]
+
+    @classmethod
+    def load(cls, npz_path):
+        d = np.load(npz_path)
+        n = int(d["n_hidden"])
+        hidden = [(d[f"h{i}_w"].astype(np.float32), d[f"h{i}_b"].astype(np.float32)) for i in range(n)]
+        return cls(
+            hidden,
+            d["out_w"].astype(np.float32), d["out_b"].astype(np.float32),
+            d["obs_mean"].astype(np.float32), d["obs_var"].astype(np.float32),
+            float(d["clip_obs"]), float(d["epsilon"]),
+        )
+
+    def normalize(self, obs):
+        z = (np.asarray(obs, np.float32) - self.obs_mean) / np.sqrt(self.obs_var + self.epsilon)
+        return np.clip(z, -self.clip_obs, self.clip_obs)
+
+    def predict(self, obs_raw):
+        """RAW obs (obs_dim,) -> deterministic action (act_dim,)."""
+        x = self.normalize(obs_raw)
+        for w, b in self.hidden:
+            x = silu(x @ w.T + b)
+        return (x @ self.out_w.T + self.out_b).astype(np.float32)

--- a/scripts/deploy/requirements-deploy.txt
+++ b/scripts/deploy/requirements-deploy.txt
@@ -1,15 +1,18 @@
-# Minimal deps to run scripts/deploy/ on the Raspberry Pi.
-# The Pi does NOT need mujoco / gymnasium / the training stack — only these.
-# Versions pinned to the dev machine that trained the model, so PPO.load() doesn't
-# hit a version-mismatch error.
+# Deps to run scripts/deploy/ on the Raspberry Pi.
+# The Pi does NOT need mujoco / gymnasium / the training stack.
 
+# ---- Recommended: torch-free NumPy policy (export with export_policy.py on the dev box) ----
+# This is ALL the Pi needs to run deploy_standing.py --policy-npz <bundle>.npz
 numpy==2.4.6
 pyyaml==6.0.3
-stable-baselines3==2.8.0
-torch==2.12.0          # CPU build. On Pi OS use piwheels (https://www.piwheels.org/) or
-                       # the official aarch64 wheel; the +cpu suffix is fine.
 
-# --- hardware libs (Pi only; hardware.py lazy-imports them, so --dry-run works without) ---
+# ---- hardware libs (Pi only; hardware.py lazy-imports them, so --dry-run works without) ----
 # smbus2                 # ICM-20948 over I2C
 # feetech-servo-sdk      # SCS bus servos (a.k.a. scservo_sdk). If you use Waveshare's
 #                        # vendored scservo_sdk source instead, drop it on the PYTHONPATH.
+
+# ---- Optional: SB3/torch backend (only if running the .zip directly, not the .npz) ----
+# Heavyweight on ARM; prefer the NumPy bundle above. Versions pinned to the training box
+# so PPO.load() doesn't hit a version mismatch.
+# stable-baselines3==2.8.0
+# torch==2.12.0          # CPU build; on Pi use piwheels (https://www.piwheels.org/)


### PR DESCRIPTION
Lets the Raspberry Pi run the standing policy with **numpy only** — no torch, no stable-baselines3, no pickle. The policy is a small `[512,512,256]` SiLU MLP, so we export it to a ~2 MB `.npz` instead of shipping the torch/SB3 stack to ARM.

## Changes
- **`export_policy.py`** (dev box): dumps the policy weights **and** VecNormalize stats to `models/real_standing_policy.npz`, self-checking parity against SB3's unclipped Gaussian mean (asserts <1e-4; measured **4.8e-7**).
- **`numpy_policy.py`**: pure-NumPy forward pass (`normalize → [Linear+SiLU]×3 → Linear`), owns its obs normalization.
- **`deploy_standing.py`**: `--policy-npz <bundle>` selects the NumPy backend (no torch/SB3 import); default still loads the `.zip` + `.pkl`. **Dry-run output is byte-identical** across both backends.
- **`requirements-deploy.txt`**: NumPy path needs only `numpy` + `pyyaml`; torch/SB3 now an optional fallback.
- **`.gitignore`**: ignore `models/*.npz` (deploy artifact — `scp` to the Pi like the `.zip`/`.pkl`).

## Verification
```
export_policy.py  -> parity max|numpy - sb3 mean| = 4.77e-07, wrote 2.07 MB npz
deploy_standing.py --dry-run --policy-npz ...  ==  deploy_standing.py --dry-run   (identical action)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)