### PR TITLE
Wire hardware.py to the real robot drivers (serial-SCS + ICM-20948)

### DIFF
--- a/scripts/deploy/hardware.py
+++ b/scripts/deploy/hardware.py
@@ -3,12 +3,11 @@
 """
 Hardware seam: servo bus + IMU drivers for the Raspberry Pi.
 
->>> THIS IS THE ONE FILE TO RECONCILE WITH YOUR EXISTING Pi DRIVER. <<<
-The servo control code (set_limits.py / home.json / the SCS SDK calls) lives on the Pi,
-not in this repo, so the calls below are written against the standard Waveshare/Feetech
-`scservo_sdk` (SCSCL protocol for SCS-series servos) and `smbus2` for the ICM-20948.
-If your Pi uses different call signatures, change them HERE only — the rest of the deploy
-code talks to ServoBus / IMU, not the SDK.
+Wired to the robot's actual drivers (reverse-engineered from the working bench scripts
+~/move_servo.py, ~/read_positions.py, ~/stop_all.py, ~/read_imu.py):
+  - Servos: raw Feetech-SCS half-duplex serial over pyserial (/dev/ttyAMA0 @ 1 Mbaud).
+            NOT scservo_sdk. Packet = FF FF id len instr params... checksum.
+  - IMU:    ICM-20948 over I2C (smbus) bus 1 @ 0x68, accel 0x2D / gyro 0x33.
 
 All hardware imports are lazy so this module imports fine on the dev machine (Windows)
 for logic/unit testing; they only fail if you actually open the bus without the libs.
@@ -18,45 +17,67 @@ from __future__ import annotations
 import time
 import numpy as np
 
-# Memory project-servo-mapping: /dev/ttyAMA0, 1000000 baud, Waveshare driver board.
 DEFAULT_PORT = "/dev/ttyAMA0"
 DEFAULT_BAUD = 1_000_000
 
+# Feetech SCS control-table registers
+REG_TORQUE_ENABLE = 0x28
+REG_GOAL_POSITION = 0x2A
+REG_PRESENT_POSITION = 0x38
+
+
+def _checksum(idv, length, instr, params):
+    return (~(idv + length + instr + sum(params))) & 0xFF
+
 
 class ServoBus:
-    """Thin wrapper over scservo_sdk SCSCL. Positions are in raw servo units (0..1023)."""
+    """Raw-serial Feetech SCS bus. Positions are servo units (0..1023)."""
 
     def __init__(self, port: str = DEFAULT_PORT, baud: int = DEFAULT_BAUD):
         self.port, self.baud = port, baud
-        self._ph = None   # PortHandler
-        self._pk = None   # scscl packet handler
+        self._ser = None
 
     def connect(self):
-        # Lazy import so the dev machine can import this module without the SDK.
-        from scservo_sdk import PortHandler, scscl  # type: ignore
-        self._ph = PortHandler(self.port)
-        if not self._ph.openPort():
-            raise RuntimeError(f"failed to open {self.port}")
-        if not self._ph.setBaudRate(self.baud):
-            raise RuntimeError(f"failed to set baud {self.baud}")
-        self._pk = scscl(self._ph)
+        import serial  # pyserial
+        self._ser = serial.Serial(self.port, self.baud, timeout=0.05)
         return self
 
-    # ---- per-servo ops (servo_id is the physical bus ID 1..17) ----
-    def read_pos(self, servo_id: int) -> int:
-        pos, _, comm, err = self._pk.ReadPos(servo_id)
-        if comm != 0 or err != 0:
-            raise IOError(f"ReadPos id={servo_id} comm={comm} err={err}")
-        return int(pos)
+    def _send(self, idv, instr, params, drain_ack=False):
+        length = len(params) + 2
+        cs = _checksum(idv, length, instr, params)
+        self._ser.write(bytes([0xFF, 0xFF, idv, length, instr, *params, cs]))
+        # Half-duplex bus: a write returns a 6-byte status packet. Draining it before the
+        # next command prevents that reply from colliding with the next write (which dropped
+        # a servo during batched homing). Mirrors the working bench scripts' move().
+        if drain_ack:
+            self._ser.read(6)
 
-    def write_pos(self, servo_id: int, units: int, speed: int = 0, accel: int = 0):
-        # SCSCL.WritePos(id, position, time, speed). time=0 -> use speed.
-        comm, err = self._pk.WritePos(servo_id, int(units), 0, int(speed))
-        if comm != 0 or err != 0:
-            raise IOError(f"WritePos id={servo_id} comm={comm} err={err}")
+    def read_pos(self, servo_id: int, retries: int = 2):
+        """Present position (units) or None after retries. (reg 0x38, 2 bytes)
+
+        The half-duplex bus occasionally drops/garbles a reply; retry rather than feed a
+        NaN into the obs. Each attempt is bounded by the serial read timeout."""
+        for _ in range(retries + 1):
+            self._ser.reset_input_buffer()
+            self._send(servo_id, 0x02, [REG_PRESENT_POSITION, 0x02])
+            resp = self._ser.read(8)
+            if len(resp) >= 7 and resp[0] == 0xFF and resp[1] == 0xFF:
+                return (resp[5] << 8) | resp[6]
+        return None
+
+    def write_pos(self, servo_id: int, units: int, speed: int = 0):
+        u = int(units) & 0xFFFF
+        s = int(speed) & 0xFFFF
+        self._send(servo_id, 0x03,
+                   [REG_GOAL_POSITION, (u >> 8) & 0xFF, u & 0xFF, (s >> 8) & 0xFF, s & 0xFF],
+                   drain_ack=True)
 
     def read_all(self, servo_ids) -> np.ndarray:
-        return np.array([self.read_pos(i) for i in servo_ids], dtype=np.float32)
+        out = []
+        for i in servo_ids:
+            p = self.read_pos(int(i))
+            out.append(float(p) if p is not None else np.nan)
+        return np.array(out, dtype=np.float32)
 
     def write_all(self, servo_ids, units, speed: int = 0):
         for sid, u in zip(servo_ids, np.asarray(units).tolist()):
@@ -64,67 +85,80 @@ class ServoBus:
 
     def set_torque(self, servo_ids, enable: bool):
         for sid in servo_ids:
-            try:
-                self._pk.write1ByteTxRx(int(sid), 40, 1 if enable else 0)  # reg 40 = torque enable
-            except Exception:
-                pass
+            self._send(int(sid), 0x03, [REG_TORQUE_ENABLE, 1 if enable else 0], drain_ack=True)
 
     def close(self):
-        if self._ph is not None:
+        if self._ser is not None:
             try:
-                self._ph.closePort()
+                self._ser.close()
             except Exception:
                 pass
 
 
 class IMU:
-    """ICM-20948 accel+gyro over I2C (memory project-sensor-bringup: 0x68, NCS->3.3V for I2C).
+    """ICM-20948 accel+gyro over I2C (bus 1, 0x68). Returns vectors already remapped into
+    the SIM BASE FRAME via `axis_remap` (a 3x3 signed permutation you calibrate once)."""
 
-    Returns vectors already remapped into the SIM BASE FRAME via `axis_remap` (a 3x3 signed
-    permutation you calibrate once), so proj_grav / ang_vel match what standing_env computed.
-    """
+    # ICM-20948 bank-0 registers (from ~/read_imu.py)
+    REG_BANK_SEL = 0x7F
+    PWR_MGMT_1 = 0x06
+    ACCEL_XOUT_H = 0x2D
+    GYRO_XOUT_H = 0x33
+    ACC_LSB_PER_G = 16384.0     # +/-2g default
+    GYRO_LSB_PER_DPS = 131.0    # +/-250 dps default
 
-    def __init__(self, addr: int = 0x68, axis_remap: np.ndarray | None = None):
-        self.addr = addr
+    def __init__(self, bus: int = 1, addr: int = 0x68, axis_remap: np.ndarray | None = None):
+        self.busnum, self.addr = bus, addr
         self._bus = None
-        # Identity by default. MUST be calibrated to the physical IMU mounting (handoff item #2).
+        # Identity by default. CALIBRATE to the physical IMU mounting (handoff item #2):
+        # upright, projected_gravity() must read ~[0,0,-1].
         self.axis_remap = np.eye(3, dtype=np.float32) if axis_remap is None else np.asarray(axis_remap, np.float32)
         self.gyro_bias = np.zeros(3, dtype=np.float32)
 
     def connect(self):
-        from smbus2 import SMBus  # type: ignore
-        self._bus = SMBus(1)
-        # TODO: wake from sleep + set ranges per ICM-20948 datasheet (PWR_MGMT_1, etc.).
-        # Left to your existing bring-up code; values below assume it's already configured.
+        try:
+            import smbus
+        except ImportError:
+            import smbus2 as smbus
+        self._bus = smbus.SMBus(self.busnum)
+        self._bus.write_byte_data(self.addr, self.REG_BANK_SEL, 0x00)  # bank 0
+        time.sleep(0.01)
+        self._bus.write_byte_data(self.addr, self.PWR_MGMT_1, 0x01)    # wake, auto clock
+        time.sleep(0.05)
         return self
 
-    def _read_accel_raw(self) -> np.ndarray:
-        # TODO: replace with your ICM-20948 register reads. Must return g-units, sensor frame.
-        raise NotImplementedError("wire to your ICM-20948 accel registers")
+    @staticmethod
+    def _s16(hi, lo):
+        v = (hi << 8) | lo
+        return v - 65536 if v & 0x8000 else v
 
-    def _read_gyro_raw(self) -> np.ndarray:
-        # TODO: replace with your ICM-20948 register reads. Must return rad/s, sensor frame.
-        raise NotImplementedError("wire to your ICM-20948 gyro registers")
+    def _read_accel_g(self) -> np.ndarray:
+        a = self._bus.read_i2c_block_data(self.addr, self.ACCEL_XOUT_H, 6)
+        return np.array([self._s16(a[0], a[1]), self._s16(a[2], a[3]), self._s16(a[4], a[5])],
+                        dtype=np.float32) / self.ACC_LSB_PER_G
+
+    def _read_gyro_rads(self) -> np.ndarray:
+        g = self._bus.read_i2c_block_data(self.addr, self.GYRO_XOUT_H, 6)
+        dps = np.array([self._s16(g[0], g[1]), self._s16(g[2], g[3]), self._s16(g[4], g[5])],
+                       dtype=np.float32) / self.GYRO_LSB_PER_DPS
+        return np.deg2rad(dps)  # sim base_ang_vel (qvel) is rad/s
 
     def projected_gravity(self) -> np.ndarray:
         """proj_grav in sim base frame. At rest accel reads +1g UP = -proj_grav, so feed
         -normalize(accel) (handoff). Valid when quasi-static (true for standing)."""
-        a = self._read_accel_raw().astype(np.float32)
+        a = self._read_accel_g()
         n = np.linalg.norm(a)
         a = a / n if n > 1e-6 else a
         return (self.axis_remap @ (-a)).astype(np.float32)
 
     def angular_velocity(self) -> np.ndarray:
-        """base_ang_vel (rad/s) in sim base frame = remapped gyro minus bias."""
-        g = self._read_gyro_raw().astype(np.float32)
-        return (self.axis_remap @ g - self.gyro_bias).astype(np.float32)
+        return (self.axis_remap @ self._read_gyro_rads() - self.gyro_bias).astype(np.float32)
 
     def calibrate_gyro_bias(self, seconds: float = 2.0, hz: float = 100.0):
-        """Average the (remapped) gyro while the robot is held still."""
         n = max(1, int(seconds * hz))
         acc = np.zeros(3, dtype=np.float32)
         for _ in range(n):
-            acc += self.axis_remap @ self._read_gyro_raw().astype(np.float32)
+            acc += self.axis_remap @ self._read_gyro_rads()
             time.sleep(1.0 / hz)
         self.gyro_bias = acc / n
         return self.gyro_bias


### PR DESCRIPTION
Replaces the `scservo_sdk` placeholder in `hardware.py` with the robot's **actual** drivers, reverse-engineered from the working bench scripts (`move_servo.py`, `read_positions.py`, `read_imu.py`) and **validated against the real hardware over SSH**.

## Changes
- **ServoBus** — raw Feetech-SCS half-duplex serial (pyserial, `/dev/ttyAMA0` @ 1 Mbaud): present pos `0x38`, goal+speed `0x2A`, torque `0x28`, checksum `~(id+len+instr+sum(params))`.
- **write_pos / set_torque drain the 6-byte status ACK** — on the half-duplex bus the reply otherwise collides with the next write (this silently dropped a servo during batched homing).
- **read_pos retries** a dropped/garbled reply instead of feeding a `NaN` into the obs.
- **IMU** — ICM-20948 over `smbus` (bus 1, `0x68`), accel `0x2D` / gyro `0x33`, gyro dps→rad/s; `projected_gravity() = -normalize(accel)`.

## Verified on hardware
- Servo reads match `read_positions.py`; homed all 17 within ~1.2°.
- `projected_gravity()` ≈ `[0,0,-1]` upright.
- Read reliability: **0 failures / 170 reads**; `read_all(17)` = **6.6 ms** (~152 Hz) → 40 Hz loop is feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)