### PR TITLE
Chest-mounted IMU -> pelvis frame transform

### DIFF
--- a/scripts/deploy/deploy_standing.py
+++ b/scripts/deploy/deploy_standing.py
@@ -108,6 +108,9 @@ def main():
     p.add_argument("--speed", type=int, default=0, help="servo move speed (0=max)")
     p.add_argument("--require-verified", action="store_true",
                    help="refuse to drive joints whose sign is not bench-verified")
+    p.add_argument("--imu-on-chest", action="store_true",
+                   help="IMU is mounted on the chest (above the waist joints): rotate proj_grav/"
+                        "ang_vel into the pelvis frame using the live waist encoder angles.")
     p.add_argument("--dry-run", action="store_true", help="no hardware: load, predict once with zero sensors, print")
     args = p.parse_args()
 
@@ -170,11 +173,23 @@ def main():
     bus = ServoBus().connect()
     imu = IMU().connect()
 
+    # waist joint indices (for the chest->pelvis IMU transform)
+    dof_idx = {j.dof: j.idx for j in m.joints}
+    waist_ix = [dof_idx["waist_roll"], dof_idx["waist_pitch"], dof_idx["waist_yaw"]]
+    if args.imu_on_chest:
+        from imu_frame import chest_to_pelvis  # noqa: E402
+        print(f"IMU-on-chest: rotating proj_grav/ang_vel to pelvis frame via waist idx {waist_ix}")
+
     def read_sensors():
         pg = imu.projected_gravity()
         av = imu.angular_velocity()
         units = bus.read_all(m.servo_ids)
-        jpos = (m.units_to_rad(units) - m.default_joint_pos).astype(np.float32)
+        abs_rad = m.units_to_rad(units)                    # absolute joint angles (sim, 0=straight)
+        if args.imu_on_chest:
+            R = chest_to_pelvis(*abs_rad[waist_ix])
+            pg = (R @ pg).astype(np.float32)
+            av = (R @ av).astype(np.float32)
+        jpos = (abs_rad - m.default_joint_pos).astype(np.float32)
         return pg, av, jpos
 
     try:

--- a/scripts/deploy/imu_frame.py
+++ b/scripts/deploy/imu_frame.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# imu_frame.py
+"""
+Transform IMU readings from the CHEST body (where the IMU is physically mounted) into the
+PELVIS / base_link frame that the policy's observation is defined in.
+
+The chest (MJCF body 0003_8) sits above the 3 waist joints, which are bent even at the home
+pose (~7.3 deg), so a chest IMU reads a tilted gravity the policy would fight. Using the live
+waist encoder angles we rotate proj_grav / ang_vel back into the pelvis frame.
+
+Validated against humanoid_real_v2.xml: the composed rotation equals the sim's chest->pelvis
+to 1e-16 and recovers proj_grav exactly (7.3 deg uncorrected tilt at home).
+
+NOTE: ang_vel is rotation-only here (R @ gyro). The exact pelvis rate also subtracts the waist
+joint-rate contribution, but that is ~0 during standing and would inject finite-diff noise, so
+it is omitted in v1.
+"""
+import numpy as np
+
+# Waist joint axes in the pelvis-aligned frame (from humanoid_real_v2.xml):
+#   idx 8  waist_roll  = Revolute 22, axis (-1, 0, 0)
+#   idx 9  waist_pitch = Revolute 20, axis (0, -0.999979, 0.006517)
+#   idx 10 waist_yaw   = Revolute 19, axis (0,  0.006517, 0.999979)
+A_ROLL = np.array([-1.0, 0.0, 0.0])
+A_PITCH = np.array([0.0, -0.999979, 0.006517])
+A_YAW = np.array([0.0, 0.006517, 0.999979])
+
+
+def _rot(axis, theta):
+    k = axis / np.linalg.norm(axis)
+    K = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]])
+    return np.eye(3) + np.sin(theta) * K + (1.0 - np.cos(theta)) * (K @ K)
+
+
+def chest_to_pelvis(waist_roll, waist_pitch, waist_yaw) -> np.ndarray:
+    """R (3x3) such that v_pelvis = R @ v_chest, from the 3 waist angles (sim radians, 0=straight)."""
+    return (_rot(A_ROLL, waist_roll) @ _rot(A_PITCH, waist_pitch) @ _rot(A_YAW, waist_yaw)).astype(np.float32)


### PR DESCRIPTION
The IMU ended up in the **chest** (no room on the pelvis), which sits above the 3 waist joints. Those are bent even at the home pose (~**7.3°**), so a chest IMU reads a phantom tilt the policy would fight — it'd lean to correct a tilt that isn't there.

## Fix
`imu_frame.chest_to_pelvis(waist_roll, waist_pitch, waist_yaw)` rotates `proj_grav` / `ang_vel` from the chest frame back into the pelvis/base_link frame the obs is defined in, using the **live waist encoder angles** (Rodrigues composition over the 3 waist axes from `humanoid_real_v2.xml`). Enabled with `deploy_standing.py --imu-on-chest`.

## Validation
Checked against the MJCF as ground truth:
- composed rotation == sim chest→pelvis to **1e-16**
- a chest IMU at home reads `[0.10, −0.08, −0.99]` (7.3° tilt) → corrected to `[0, 0, −1]` exactly

`ang_vel` is rotation-only (the waist joint-rate term is ~0 during standing and would inject finite-diff noise). Live hardware check deferred — Pi went offline mid-session; the math is sim-validated and it'll be exercised on next `git pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)