### PR TITLE
IMU mounting calibration (180° about Z axis remap)

### DIFF
--- a/config/imu_calib.yaml
+++ b/config/imu_calib.yaml
@@ -1,0 +1,16 @@
+# IMU mounting calibration for the real robot.
+# axis_remap maps the raw IMU sensor axes -> the chest body frame:
+#     proj_grav  = axis_remap @ (-accel_normalized)
+#     ang_vel    = axis_remap @ gyro_rads - gyro_bias
+#
+# Derived 2026-06-18 by hand-tilt calibration: the IMU/breadboard is mounted rotated
+# 180 deg about the vertical (Z) axis (it faces backward), so X and Y are negated and
+# Z is unchanged. Confirmed by pitch-forward (X sign) + left/right-roll (Y sign) tilt
+# tests against the MJCF ground truth; end-to-end upright read ~9.5 deg (mostly hand-hold).
+#
+# TODO refine the residual static tilt (~few deg) once the robot can be held truly level
+# on a stand — average corrected proj_grav at known-upright and fold the offset in here.
+axis_remap:
+  - [-1, 0, 0]
+  - [0, -1, 0]
+  - [0, 0, 1]

--- a/scripts/deploy/deploy_standing.py
+++ b/scripts/deploy/deploy_standing.py
@@ -22,6 +22,7 @@ Defaults match the deployed model:
 
 from __future__ import annotations
 import argparse
+import os
 import pickle
 import sys
 import time
@@ -111,6 +112,8 @@ def main():
     p.add_argument("--imu-on-chest", action="store_true",
                    help="IMU is mounted on the chest (above the waist joints): rotate proj_grav/"
                         "ang_vel into the pelvis frame using the live waist encoder angles.")
+    p.add_argument("--imu-calib", default=str(ROOT / "config" / "imu_calib.yaml"),
+                   help="YAML with axis_remap (raw IMU axes -> chest frame). Identity if missing.")
     p.add_argument("--dry-run", action="store_true", help="no hardware: load, predict once with zero sensors, print")
     args = p.parse_args()
 
@@ -170,8 +173,14 @@ def main():
 
     # ---- hardware ----
     from hardware import ServoBus, IMU  # noqa: E402
+    axis_remap = None
+    if os.path.exists(args.imu_calib):
+        import yaml  # noqa: E402
+        with open(args.imu_calib) as f:
+            axis_remap = np.asarray(yaml.safe_load(f)["axis_remap"], dtype=np.float32)
+        print(f"IMU axis_remap loaded from {args.imu_calib}:\n{axis_remap}")
     bus = ServoBus().connect()
-    imu = IMU().connect()
+    imu = IMU(axis_remap=axis_remap).connect()
 
     # waist joint indices (for the chest->pelvis IMU transform)
     dof_idx = {j.dof: j.idx for j in m.joints}


### PR DESCRIPTION
Hand-tilt calibration over SSH (reading `proj_grav` while tilting the robot in known directions, vs MJCF ground truth) found the chest IMU is mounted **rotated 180° about the vertical axis** (faces backward):

| Tilt | raw | after remap | sim wants |
|---|---|---|---|
| Pitch forward | X = −0.44 | **+0.44** | +0.57 |
| Right-side down | Y = +0.55 | **−0.55** | −0.55 |
| Left-side down | Y = −0.90 | **+0.90** | +0.42 |

→ `axis_remap = diag(-1, -1, 1)`.

## Changes
- **`config/imu_calib.yaml`** — the remap, with a TODO to refine the residual static tilt (~9.5° end-to-end at hand-held upright, mostly how level it was held) once the robot can sit truly level.
- **`deploy_standing.py`** — `--imu-calib` loads `axis_remap` and passes it to `IMU()`. Combined with `--imu-on-chest` (the waist transform), the full chain is raw → 180° remap → chest→pelvis.

All three tilt-sign tests match the MJCF; end-to-end upright read 9.5° (acceptable, hand-held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)