### PR TITLE
Sim2real standing: balance-stance + push-recovery + gain penalty + diagnostics

### DIFF
--- a/config/real_humanoid_balanced.yaml
+++ b/config/real_humanoid_balanced.yaml
@@ -1,0 +1,165 @@
+# BALANCED-STANCE retrain for the real humanoid standing policy.
+#
+# ROOT CAUSE (6/23, found by hardware elimination): the policy stands in sim but limit-cycles
+# / tips on hardware because it learned a LOPSIDED, essentially-one-leg standing pose. The
+# dry-run at a perfect upright+home obs commands an asymmetric stance (R knee bent 4x the L,
+# weight shifted right). Freezing that pose on the robot open-loop -> it can't stand ("legs
+# weren't in the right place, essentially on one leg"). The model is SYMMETRIC (L/R leg masses
+# and inertias are identical), so this is purely a learned-policy artifact: nothing in the
+# reward required a symmetric two-foot stance, so PPO settled into a weight-shifted local
+# optimum the forgiving sim tolerates but the real robot tips off of.
+#
+# Everything else checked out: 40 Hz loop (not bus-bound), never tips in the obs, IMU on the
+# MJCF root (pelvis), gyro honest + correct units, servo step-response clean 1st-order (matches
+# the actuator_lag model), and command-chatter / joint-stiffness / gyro-feedback tweaks did NOT
+# stop the sway -- because the sway is the policy fighting its own un-balanceable one-leg pose.
+#
+# FIX: new reward term stance_balance_weight -- rewards EVEN weight on both feet + a COM centered
+# horizontally over them, so the learned nominal stance becomes a balanced two-foot stand that
+# transfers. Plus push-recovery (random root velocity kicks): you cannot catch a shove on one
+# leg, so pushes reinforce two-foot balance and broaden the state distribution. Keeps the
+# smoothness penalty + measured actuator lag from the smooth run.
+#
+# Resumes the SMOOTH model and writes *_balanced outputs:
+#   python scripts/train_standing.py --config config/real_humanoid_balanced.yaml \
+#     --model models/final_real_standing_smooth.zip \
+#     --vecnorm models/vecnorm_real_standing_smooth.pkl \
+#     --timesteps 25000000
+#
+# SUCCESS GATE (before deploying): re-run the dry-run
+#   python scripts/deploy/deploy_standing.py --policy-npz <exported>.npz --dry-run
+# and confirm the commanded pose is now ~SYMMETRIC (L/R knee + hip within a few hundredths,
+# weight not shifted). Then the --freeze-after test must STAND when held, not tip onto one leg.
+
+standing:
+  # ========== ENVIRONMENT ==========
+  xml_file: models/humanoid_real_v2.xml
+  seed: 42
+  n_envs: 12
+  device: cuda
+  max_episode_steps: 5000
+
+  # ========== OBSERVATION (deployable proprioceptive, 228-dim) ==========
+  proprioceptive_obs: true
+  obs_foot_contact: false       # stance reward uses sim contact; obs stays 228-dim deployable
+  obs_history: 4
+  obs_include_com: false
+  obs_feature_norm: false
+
+  # ========== ACTION + SMOOTHNESS (keep the smooth-run gains) ==========
+  action_smoothing: true
+  action_smoothing_tau: 0.3
+  action_symmetry: false        # the built-in averager is wrong for this joint layout -- leave off
+  pd_assist: false
+  action_rate_penalty: 70.0
+  action_rate_cap: 100.0
+  # RAW action-rate penalty: charges the change in the pre-smoothing network output -- the term
+  # that actually lowers the policy's noise-amplifying gain (action_rate_penalty above is on the
+  # SMOOTHED action, which the tau-EMA hides jitter from). A sensitivity probe measured ~0.1 rad
+  # of raw command jitter from sensor noise; this pressures that down.
+  raw_action_rate_penalty: 25.0
+  raw_action_rate_cap: 50.0
+  yaw_rate_penalty: 30.0
+
+  # ========== BALANCED STANCE (the primary fix) ==========
+  stance_balance_weight: 8.0    # continuous per-step bonus for even-footed, COM-centered stance
+
+  # ========== PUSH-RECOVERY (reinforces two-foot balance) ==========
+  push_enabled: true
+  push_interval_steps: [60, 150]
+  push_lin_vel: 0.3
+  push_ang_vel: 1.0
+
+  # ========== CURRICULUM (pinned final stage) ==========
+  curriculum_start_stage: 5
+  curriculum_max_stage: 5
+  curriculum_advance_after: 20
+  curriculum_success_rate: 0.60
+
+  # ========== SIM2REAL RANDOMIZATION ==========
+  actuator_lag: true
+  actuator_delay_ms: [30.0, 70.0]
+  actuator_tau_ms: [90.0, 220.0]
+
+  actuator_rand: true
+  actuator_rand_range: [0.7, 1.3]      # widened from [0.8,1.2]: can't reproduce the real sway in
+                                       # sim, so harden against a WIDE plant range that contains it
+
+  domain_rand: true
+  curriculum_manage_domain_rand: false
+  rand_mass_range: [0.8, 1.2]          # widened from [0.9,1.1]
+  rand_friction_range: [0.6, 1.4]      # widened from [0.7,1.3]
+
+  obs_noise: true
+  noise_projgrav: 0.02
+  noise_angvel: 0.05
+  noise_jpos: 0.005
+  noise_jvel: 0.25
+  bias_jpos: 0.02
+  bias_angvel: 0.03
+
+  # ========== REWARD ==========
+  target_height: 1.40
+  height_error_threshold: 0.08
+  height_stability_threshold: 0.15
+  reward_caps:
+    max_height_maintenance_penalty: 15.0
+    recovery_bonus_scale: 50.0
+    termination_penalty_constant: 50.0
+
+  # ========== PPO (fine-tune from the smooth model) ==========
+  total_timesteps: 25_000_000
+  learning_rate: 0.0002
+  final_learning_rate: 0.00003
+  n_steps: 2048
+  batch_size: 2048
+  n_epochs: 5
+  gamma: 0.995
+  gae_lambda: 0.95
+  clip_range: 0.2
+  final_clip_range: 0.1
+  ent_coef: 0.004
+  final_ent_coef: 0.001
+  log_std_max: -1.5
+  log_std_min: -2.0
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+
+  # ========== VECNORMALIZE ==========
+  normalize: true
+  vecnormalize_clip_obs: 50.0
+  vecnormalize_clip_reward: 50.0
+
+  # ========== NETWORK (must match the smooth model to resume) ==========
+  policy_kwargs:
+    net_arch:
+      - pi: [512, 512, 256]
+        vf: [512, 512, 256]
+    activation_fn: SiLU
+    ortho_init: true
+
+  # ========== LOGGING / CHECKPOINTING (distinct *_balanced paths) ==========
+  verbose: 1
+  log_dir: data/logs/real_standing_balanced
+  use_tensorboard: true
+  n_eval_episodes: 5
+  eval_freq: 100_000
+  save_freq: 250_000
+  checkpoint_dir: data/checkpoints/real_standing_balanced
+  checkpoint_prefix: real_standing_balanced
+  best_model_path: models/best_real_standing_balanced
+  final_model_path: models/final_real_standing_balanced
+  vecnormalize_path: models/vecnorm_real_standing_balanced.pkl
+  target_reward_threshold: 5000
+  early_stop:
+    patience: 5
+
+  random_height_init: false
+  random_height_prob: 0.0
+  random_height_range: [-0.3, 0.1]
+
+  use_wandb: false
+  wandb_project: humanoid_real_standing_balanced
+  wandb_log_freq: 10000
+  video_freq: 500000
+  episode_print_freq: 1000

--- a/scripts/deploy/deploy_standing.py
+++ b/scripts/deploy/deploy_standing.py
@@ -71,11 +71,12 @@ class ObsBuilder:
     """Maintains history + finite-diff joint velocity, emits the 228-dim obs."""
 
     def __init__(self, m: SimRealMap, dt: float, jvel_alpha: float = 0.35,
-                 jvel_clamp: float = 2.5):
+                 jvel_clamp: float = 2.5, zero_jvel: bool = False):
         self.m = m
         self.dt = dt
         self.jvel_alpha = float(jvel_alpha)
         self.jvel_clamp = float(jvel_clamp)
+        self.zero_jvel = bool(zero_jvel)
         self.hist = deque(maxlen=HISTORY)
         self.prev_jpos = None
         self.jvel_f = np.zeros(NJ, dtype=np.float32)      # low-passed joint velocity
@@ -99,7 +100,8 @@ class ObsBuilder:
         # is still noisier than sim; alpha=1.0 disables (raw), lower = smoother.
         a = self.jvel_alpha
         self.jvel_f = ((1.0 - a) * self.jvel_f + a * jraw).astype(np.float32)
-        return np.concatenate([proj_grav, ang_vel, jpos, self.jvel_f, self.last_action]).astype(np.float32)
+        jvel_out = np.zeros(NJ, dtype=np.float32) if self.zero_jvel else self.jvel_f
+        return np.concatenate([proj_grav, ang_vel, jpos, jvel_out, self.last_action]).astype(np.float32)
 
     def obs(self, frame):
         self.hist.append(frame)
@@ -135,6 +137,23 @@ def main():
     p.add_argument("--speed", type=int, default=0, help="servo move speed (0=max)")
     p.add_argument("--jvel-alpha", type=float, default=0.35,
                    help="low-pass on joint-velocity obs (1.0=raw/off, lower=smoother; anti-jitter)")
+    p.add_argument("--zero-angvel", action="store_true",
+                   help="DIAGNOSTIC: feed zeros for the base angular-velocity obs channel. If the "
+                        "limit-cycle sway STOPS, the gyro feedback is driving it (likely a flipped "
+                        "sign -> anti-damping). If it keeps swaying, the gyro is not the engine.")
+    p.add_argument("--zero-jvel", action="store_true",
+                   help="DIAGNOSTIC: feed zeros for the joint-velocity obs channel. A sensitivity "
+                        "probe shows the policy amplifies jvel noise into ~0.13 rad of command "
+                        "jitter; for a standing robot true jvel ~ 0, so if the jitter DROPS with "
+                        "jvel zeroed, the noisy finite-diff jvel is the jitter source.")
+    p.add_argument("--freeze-after", type=int, default=0,
+                   help="DIAGNOSTIC: run closed-loop for N steps to reach the policy's standing "
+                        "pose, then FREEZE the command and hold it open-loop (sensors still read "
+                        "for the safety cut). A fixed target can't limit-cycle, so this isolates "
+                        "static balance from control instability: if the frozen pose HOLDS (stands "
+                        "on release), the policy's pose is statically stable and the sway is a "
+                        "feedback instability; if it TIPS, the policy's target pose itself is not "
+                        "balanced on the real robot (mass/pose mismatch). 0 = off.")
     p.add_argument("--debug", action="store_true", help="print obs/action diagnostics each --debug-every steps")
     p.add_argument("--debug-every", type=int, default=10)
     p.add_argument("--require-verified", action="store_true",
@@ -170,7 +189,8 @@ def main():
         infer = _SB3Backend(model, mean, var, eps, clip).predict
         print(f"Policy: SB3 {args.model} + vecnorm (obs_dim={OBS_DIM}, clip={clip})")
 
-    builder = ObsBuilder(m, dt, jvel_alpha=args.jvel_alpha, jvel_clamp=args.jvel_clamp)
+    builder = ObsBuilder(m, dt, jvel_alpha=args.jvel_alpha, jvel_clamp=args.jvel_clamp,
+                         zero_jvel=args.zero_jvel)
 
     def predict_units(proj_grav, ang_vel, jpos):
         frame = builder.frame(proj_grav, ang_vel, jpos)
@@ -255,9 +275,17 @@ def main():
         prev_applied = builder.last_action.copy()
         tilt_bad = 0
         step = 0
+        frozen_units = None   # set once --freeze-after fires; held thereafter
+        loop_ms_ema = dt * 1000.0   # EMA of realized loop period; flags if the bus can't keep 40 Hz
+        t_prev = time.time()
         while True:
             t0 = time.time()
+            loop_ms_ema = 0.9 * loop_ms_ema + 0.1 * (t0 - t_prev) * 1000.0
+            t_prev = t0
             pg, av, jpos = read_sensors()
+            if args.zero_angvel:
+                av = np.zeros(3, dtype=np.float32)
+            t_sense = time.time()
 
             upright_cos = -float(pg[2])
             # Debounce: only cut after the (filtered) tilt stays past the threshold for
@@ -272,20 +300,33 @@ def main():
             else:
                 tilt_bad = 0
 
-            units, applied = predict_units(pg, av, jpos)
-            # per-step move clamp (rate limit), then write
-            units = np.clip(units, prev_units - args.max_step_units, prev_units + args.max_step_units)
-            units = np.clip(units, m.lim_lo, m.lim_hi).round().astype(int)
+            if args.freeze_after and step >= args.freeze_after:
+                if frozen_units is None:
+                    frozen_units = prev_units.astype(int)
+                    print(f"\n[FREEZE] holding the policy's pose open-loop at step {step} "
+                          f"(feedback off). Ease your hands away: does it STAND or TIP?")
+                units = frozen_units
+                applied = prev_applied   # keep debug readout sane
+            else:
+                units, applied = predict_units(pg, av, jpos)
+                # per-step move clamp (rate limit), then write
+                units = np.clip(units, prev_units - args.max_step_units, prev_units + args.max_step_units)
+                units = np.clip(units, m.lim_lo, m.lim_hi).round().astype(int)
             bus.write_all(m.servo_ids, units, speed=args.speed)
             prev_units = units.astype(float)
 
             if args.debug and step % args.debug_every == 0:
+                sense_ms = (t_sense - t0) * 1000.0
+                busy_ms = (time.time() - t0) * 1000.0   # sense+predict+write, before sleep
+                rate = 1000.0 / loop_ms_ema if loop_ms_ema > 0 else 0.0
+                slow = "  <<SLOW: bus-bound, real Hz < target" if busy_ms > dt * 1000.0 else ""
                 print(f"[{step:5d}] pg=[{pg[0]:+.2f},{pg[1]:+.2f},{pg[2]:+.2f}] "
                       f"|av|={np.linalg.norm(av):.2f} "
                       f"max|jvel_raw|={np.max(np.abs(builder.last_jvel_raw)):5.1f} "
                       f"max|jvel_f|={np.max(np.abs(builder.jvel_f)):5.1f} "
                       f"max|act|={np.max(np.abs(applied)):.2f} "
-                      f"d_act={np.max(np.abs(applied - prev_applied)):.3f}")
+                      f"d_act={np.max(np.abs(applied - prev_applied)):.3f} "
+                      f"| {rate:4.1f}Hz sense={sense_ms:4.1f}ms busy={busy_ms:4.1f}ms{slow}")
             prev_applied = applied.copy()
             step += 1
 

--- a/scripts/deploy/servo_stiffness.py
+++ b/scripts/deploy/servo_stiffness.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# servo_stiffness.py  --  RUN ON THE PI
+"""
+Make the load-bearing servos hold POSITION more rigidly under load, to narrow the #1
+sim2real gap for standing: the sim joints are perfectly rigid, but the real SCS servos sag
+and wobble under the body's weight, so the policy's balance strategy goes unstable (1-2 rad/s
+limit-cycle sway). Stiffening the joints moves the real plant toward the rigid sim hinge the
+policy was trained on.
+
+This firmware uses a position PID (confirmed by reading the table -- reg 21/22/23 = P/D/I
+hold sane values, the AX compliance-slope regs 28/29 are vestigial). STIFFNESS = P (reg 21):
+RAISE it to make the joint hold position more firmly under load. Default P here is ~15 (soft);
+try 24, then 32. Too high makes the servo buzz/overshoot in its OWN loop, so step up and watch.
+Optionally adjust D (reg 22): the stock D=15 is high (sluggish hold) -- lowering D can sharpen
+the response, but change ONE thing at a time.
+
+This tool READS the current registers first (always, even when writing) so you can revert,
+and READS BACK after writing to confirm it stuck. EEPROM is LOCK-protected (reg 48):
+unlock(0) -> write -> relock(1). Defaults to the LEGS+WAIST (the load-bearing joints).
+
+  python3 servo_stiffness.py --read-only                 # inspect legs+waist, write nothing
+  python3 servo_stiffness.py --read-only --all           # inspect every servo
+  python3 servo_stiffness.py --legs --kp 24 --apply      # stiffen legs+waist: P=24
+  python3 servo_stiffness.py --legs --kp 24 --kd 8 --apply # also lower D to 8
+  python3 servo_stiffness.py --legs --kp 15 --kd 15 --apply # REVERT to stock
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from hardware import ServoBus  # noqa: E402
+
+REG_P = 21             # some SCS firmware exposes position PID here instead of slope
+REG_D = 22
+REG_I = 23
+REG_CW_MARGIN = 26
+REG_CCW_MARGIN = 27
+REG_CW_SLOPE = 28      # the stiffness lever (lower = stiffer)
+REG_CCW_SLOPE = 29
+REG_LOCK = 48          # SCSCL EEPROM lock: 0=unlocked (writable), 1=locked
+
+ARMS = list(range(12, 18))           # SCS0009 arm servos
+LEGS = list(range(1, 12))            # legs + 3-DOF waist: the load-bearing joints
+ALL = list(range(1, 18))
+
+
+def _r(bus, sid, reg):
+    v = bus.read_reg(sid, reg)
+    return v[0] if v else None
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--servo", type=int, default=None, help="single servo id")
+    p.add_argument("--legs", action="store_true", help="legs + waist (servos 1..11), the default target")
+    p.add_argument("--arms", action="store_true", help="arm servos 12..17")
+    p.add_argument("--all", action="store_true", help="all 17 servos")
+    p.add_argument("--kp", type=int, default=None, help="position P gain to set (reg 21; higher=stiffer)")
+    p.add_argument("--kd", type=int, default=None, help="position D gain to set (reg 22; optional)")
+    p.add_argument("--apply", action="store_true", help="actually write (otherwise read-only)")
+    p.add_argument("--read-only", action="store_true", help="inspect only, never write")
+    args = p.parse_args()
+
+    if args.servo is not None:
+        ids = [args.servo]
+    elif args.all:
+        ids = ALL
+    elif args.arms:
+        ids = ARMS
+    else:
+        ids = LEGS   # default
+
+    write = args.apply and not args.read_only and (args.kp is not None or args.kd is not None)
+    if args.apply and args.kp is None and args.kd is None:
+        print("--apply given but no --kp/--kd: nothing to write. (read-only shown below)")
+    for val, nm in ((args.kp, "kp"), (args.kd, "kd")):
+        if val is not None and not 0 <= val <= 100:
+            print(f"refusing {nm}={val}: stay in 0..100 (stock P/D are ~15).")
+            return
+
+    bus = ServoBus().connect()
+    try:
+        print(f"{'sid':>3}  {'P':>3} {'D':>3} {'I':>3} | {'cwMrg':>5} {'ccwMrg':>6} | "
+              f"{'cwSlp':>5} {'ccwSlp':>6}")
+        for sid in ids:
+            pP, pD, pI = _r(bus, sid, REG_P), _r(bus, sid, REG_D), _r(bus, sid, REG_I)
+            cwm, ccwm = _r(bus, sid, REG_CW_MARGIN), _r(bus, sid, REG_CCW_MARGIN)
+            cws, ccws = _r(bus, sid, REG_CW_SLOPE), _r(bus, sid, REG_CCW_SLOPE)
+            if cws is None and ccws is None:
+                print(f"{sid:>3}  NO REPLY (skipped)")
+                continue
+            print(f"{sid:>3}  {str(pP):>3} {str(pD):>3} {str(pI):>3} | {str(cwm):>5} {str(ccwm):>6} | "
+                  f"{str(cws):>5} {str(ccws):>6}", end="")
+            if not write:
+                print("  (read-only)")
+                continue
+            bus.write_reg(sid, REG_LOCK, 0)
+            if args.kp is not None:
+                bus.write_reg(sid, REG_P, args.kp)
+            if args.kd is not None:
+                bus.write_reg(sid, REG_D, args.kd)
+            bus.write_reg(sid, REG_LOCK, 1)
+            nP, nD = _r(bus, sid, REG_P), _r(bus, sid, REG_D)
+            ok = ((args.kp is None or nP == args.kp) and (args.kd is None or nD == args.kd))
+            print(f"  ->  P={nP} D={nD}  {'OK' if ok else 'FAILED (unchanged?)'}")
+    finally:
+        bus.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/environments/standing_env.py
+++ b/src/environments/standing_env.py
@@ -81,6 +81,25 @@ class StandingEnv(gym.Wrapper):
         self.bias_angvel_std = float(self.cfg.get('bias_angvel', 0.02))     # per-ep gyro bias
         self._bias_jpos = None
         self._bias_angvel = None
+
+        # OBSERVATION FILTER / LATENCY (mirror the deploy ObsBuilder so training sees the SAME
+        # delayed, filtered, finite-diff-from-quantized obs the real loop produces). Training
+        # otherwise reads exact instantaneous proj_grav/jvel with zero lag, while deploy adds a
+        # proj_grav EMA + finite-diff-of-quantized-encoder jvel + jvel EMA -- roughly doubling the
+        # balance-loop delay the policy was tuned for, which can drive a ~2 Hz limit cycle. Filter
+        # strengths are randomized per episode (observation-latency randomization) so the policy is
+        # robust across the bracket that contains the real deploy values. Off by default.
+        self.obs_filter = bool(self.cfg.get('obs_filter', False))
+        self.obs_projgrav_alpha = self.cfg.get('obs_projgrav_alpha', [0.2, 0.5])
+        self.obs_jvel_alpha = self.cfg.get('obs_jvel_alpha', [0.2, 0.5])
+        self.obs_jvel_finite_diff = bool(self.cfg.get('obs_jvel_finite_diff', True))
+        self.obs_encoder_quant = float(self.cfg.get('obs_encoder_quant', 0.005))  # rad/unit
+        self.obs_jvel_clamp = float(self.cfg.get('obs_jvel_clamp', 2.5))
+        self._obs_pg_ema = None
+        self._obs_jvel_ema = None
+        self._obs_prev_jpos_q = None
+        self._obs_pg_alpha = 0.35
+        self._obs_jvel_alpha_ep = 0.35
         # Actuator-gain randomization: real position servos differ from the MJCF kp/kv and vary
         # unit-to-unit. Scale kp/kv per episode so the policy doesn't overfit one plant.
         self.actuator_rand = bool(self.cfg.get('actuator_rand', False))
@@ -111,6 +130,27 @@ class StandingEnv(gym.Wrapper):
         self.random_height_init = self.cfg.get('random_height_init', True)
         self.random_height_prob = self.cfg.get('random_height_prob', 0.3)
         self.random_height_range = self.cfg.get('random_height_range', [-0.3, 0.1])
+
+        # Push-recovery disturbances: random VELOCITY impulses to the root during the episode
+        # (and a varied initial root velocity/tilt at reset). Without this, a standing policy
+        # only ever sees the perfect setpoint (ang_vel ~ 0) and trains a razor's-edge stabilizer
+        # that limit-cycles on hardware the instant a real disturbance kicks it out of that tiny
+        # state distribution -- exactly the measured failure (pelvis gyro hit 2.7 rad/s while the
+        # bench step-response and obs were all clean). Pushing teaches it to DAMP those excursions.
+        # Works for custom models too (unlike random_height_init, which is gated off). Training-only.
+        self.push_enabled = bool(self.cfg.get('push_enabled', False))
+        self.push_interval_steps = self.cfg.get('push_interval_steps', [50, 150])
+        self.push_lin_vel = float(self.cfg.get('push_lin_vel', 0.4))   # m/s impulse on qvel[0:3]
+        self.push_ang_vel = float(self.cfg.get('push_ang_vel', 1.5))   # rad/s impulse on qvel[3:6]
+        self._push_countdown = 0
+
+        # Balanced two-foot stance reward. The standing reward can be fully earned on a lopsided
+        # single-leg pose that the forgiving sim tolerates but the real robot tips off of (the
+        # deployed policy learned exactly that -- it froze into an "essentially on one leg" stance).
+        # Rewarding even weight on both feet + a COM centered over them pulls the learned NOMINAL
+        # stance to a balanced two-foot stand that transfers. Off by default. Custom model only
+        # (needs foot_body_ids). Reward-only -- uses sim contact/COM, not in the deployable obs.
+        self.stance_balance_weight = float(self.cfg.get('stance_balance_weight', 0.0))
         
         # Reward caps from config
         reward_caps = self.cfg.get('reward_caps', {})
@@ -143,6 +183,15 @@ class StandingEnv(gym.Wrapper):
         # jerky). Raise it (config) when smoothness is the training objective.
         self.action_rate_cap = float(self.cfg.get('action_rate_cap', 20.0))
         self._last_action_rate = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        # RAW action-rate penalty: charges the frame-to-frame change of the RAW network output
+        # (before the tau-EMA smoothing), unlike action_rate_penalty which charges the already-
+        # smoothed action and so lets the network emit jitter the EMA hides. This is the term that
+        # actually pressures the policy to be LOW-GAIN -- a sensitivity probe showed it amplifies
+        # sensor noise into ~0.1 rad of raw command jitter. 0.0 = off.
+        self.raw_action_rate_weight = float(self.cfg.get('raw_action_rate_penalty', 0.0))
+        self.raw_action_rate_cap = float(self.cfg.get('raw_action_rate_cap', 100.0))
+        self._prev_raw_action = np.zeros(self.env.action_space.shape, dtype=np.float32)
+        self._last_raw_action_rate = np.zeros(self.env.action_space.shape, dtype=np.float32)
 
         # Yaw-rate damping. Penalizes (base yaw rate)^2 to discourage the slow
         # in-place spin that proprioceptive obs can't correct via heading
@@ -318,6 +367,33 @@ class StandingEnv(gym.Wrapper):
                                      maxlen=delay_steps + 1)
             self._servo_state = zero.copy()
 
+        # Observation filter: sample this episode's EMA strengths + reset the filter states, so
+        # each episode trains a different obs latency within the bracket (matches deploy ObsBuilder).
+        if self.obs_filter:
+            self._obs_pg_alpha = float(np.random.uniform(*self.obs_projgrav_alpha))
+            self._obs_jvel_alpha_ep = float(np.random.uniform(*self.obs_jvel_alpha))
+            self._obs_pg_ema = None
+            self._obs_jvel_ema = None
+            self._obs_prev_jpos_q = None
+
+        # Push-recovery: schedule the first in-episode shove and (floor-safely, unlike
+        # random_height_init) start the episode already moving / slightly tilted so the policy
+        # trains across a WIDE state distribution, not just the perfect setpoint. Velocity/tilt
+        # only -- height is left untouched so the custom robot isn't pushed through the floor.
+        if self.push_enabled:
+            lo, hi = self.push_interval_steps
+            self._push_countdown = int(np.random.randint(int(lo), int(hi) + 1))
+            qvel = self.env.unwrapped.data.qvel
+            qvel[0:3] += np.random.uniform(-self.push_lin_vel, self.push_lin_vel, size=3)
+            qvel[3:6] += np.random.uniform(-self.push_ang_vel, self.push_ang_vel, size=3)
+            quat = self.env.unwrapped.data.qpos[3:7]   # [w,x,y,z]; nudge x/y tilt, renormalize
+            quat[1] += np.random.uniform(-0.05, 0.05)
+            quat[2] += np.random.uniform(-0.05, 0.05)
+            qn = np.linalg.norm(quat)
+            if qn > 1e-6:
+                quat /= qn
+            observation = self.env.unwrapped._get_obs()
+
         # Random height initialization for recovery training. Skip for custom
         # models: the legacy [0.6, 1.6] clip assumes a 1.40 m-target capsule
         # humanoid and would push a smaller robot through the floor or ceiling.
@@ -343,10 +419,26 @@ class StandingEnv(gym.Wrapper):
         return observation, info
     
     def step(self, action):
+        # Push-recovery: every so many steps, inject a random root velocity impulse mid-episode
+        # so the policy must actively DAMP an ang_vel/lin_vel excursion from a stable stand --
+        # the skill it needs on hardware. The kick lands in the live sim state and the next
+        # env.step integrates it, so the policy feels it through proj_grav/ang_vel like a shove.
+        if self.push_enabled:
+            self._push_countdown -= 1
+            if self._push_countdown <= 0:
+                qvel = self.env.unwrapped.data.qvel
+                qvel[0:3] += np.random.uniform(-self.push_lin_vel, self.push_lin_vel, size=3)
+                qvel[3:6] += np.random.uniform(-self.push_ang_vel, self.push_ang_vel, size=3)
+                lo, hi = self.push_interval_steps
+                self._push_countdown = int(np.random.randint(int(lo), int(hi) + 1))
+
         # Action preprocessing. Capture the previously-applied (smoothed) action
         # before _process_action overwrites prev_action, so the reward can charge
         # the per-step action rate.
         prev_applied = self.prev_action.copy()
+        raw_in = np.asarray(action, dtype=np.float32).ravel()
+        self._last_raw_action_rate = raw_in - self._prev_raw_action
+        self._prev_raw_action = raw_in.copy()
         proc_action = self._process_action(np.asarray(action, dtype=np.float32))
         self._last_action_rate = proc_action - prev_applied
 
@@ -446,6 +538,17 @@ class StandingEnv(gym.Wrapper):
         else:
             action_rate_penalty = 0.0
 
+        # RAW action-rate penalty: charge the change in the network's pre-smoothing output, the
+        # term that actually lowers the policy's noise-amplifying gain (the EMA hides this from the
+        # smoothed action_rate_penalty above).
+        if self.raw_action_rate_weight > 0.0:
+            raw_action_rate_penalty = -min(
+                self.raw_action_rate_weight * float(np.sum(np.square(self._last_raw_action_rate))),
+                self.raw_action_rate_cap,
+            )
+        else:
+            raw_action_rate_penalty = 0.0
+
         # ==========  YAW-RATE DAMPING (anti-spin) ==========
         # angular_vel = qvel[3:6] (base frame); [2] is yaw rate. Penalize its
         # square, capped, so a transient can't spike PPO value targets.
@@ -518,6 +621,27 @@ class StandingEnv(gym.Wrapper):
             else:  # Other terminations (height too high)
                 termination_penalty = -self.termination_penalty_constant * 0.5
         
+        # ========== BALANCED TWO-FOOT STANCE (anti one-leg lean) ==========
+        # Reward both feet bearing even load AND the COM centered horizontally over the feet, so
+        # the nominal standing pose is a symmetric two-foot stand rather than a sim-only one-leg
+        # lean. Gated to upright standing; reward-only (sim contact force + COM, not in obs).
+        stance_reward = 0.0
+        if self.stance_balance_weight > 0.0 and self._is_custom and height >= 1.2:
+            data = self.env.unwrapped.data
+            fids = list(self.model_spec.foot_body_ids)[:2]
+            if len(fids) == 2:
+                fL = float(np.linalg.norm(data.cfrc_ext[fids[0]][3:6]))
+                fR = float(np.linalg.norm(data.cfrc_ext[fids[1]][3:6]))
+                tot = fL + fR
+                both_down = 1.0 if (fL > 1.0 and fR > 1.0) else 0.0
+                imbalance = abs(fL - fR) / tot if tot > 1.0 else 1.0      # 0=even, 1=one foot
+                com_xy = np.asarray(data.subtree_com[0][:2], dtype=np.float64)
+                mid_xy = 0.5 * (np.asarray(data.xpos[fids[0]][:2], dtype=np.float64) +
+                                np.asarray(data.xpos[fids[1]][:2], dtype=np.float64))
+                off = float(np.linalg.norm(com_xy - mid_xy))             # COM offset from feet center
+                stance_reward = (self.stance_balance_weight * both_down *
+                                 float(np.exp(-4.0 * imbalance)) * float(np.exp(-20.0 * off ** 2)))
+
         # ========== TOTAL REWARD ==========
         total_reward = (
             height_reward +
@@ -530,7 +654,9 @@ class StandingEnv(gym.Wrapper):
             velocity_penalty +
             sustained_bonus +
             action_rate_penalty +
+            raw_action_rate_penalty +
             yaw_rate_penalty +
+            stance_reward +
             termination_penalty
         )
         
@@ -552,7 +678,7 @@ class StandingEnv(gym.Wrapper):
                 f"[h={height_reward:6.1f}, u={upright_reward:4.1f}, "
                 f"stab={stability_reward:4.1f}, recov={recovery_bonus:4.1f}, "
                 f"rate={action_rate_penalty:5.1f}, yaw={yaw_rate_penalty:5.1f}, "
-                f"bonus={sustained_bonus:.0f}]")
+                f"stance={stance_reward:4.1f}, bonus={sustained_bonus:.0f}]")
         
         return total_reward, terminate
 
@@ -721,6 +847,32 @@ class StandingEnv(gym.Wrapper):
                 base_ang_vel = base_ang_vel + self._bias_angvel
             if self._bias_jpos is not None:
                 jpos = jpos + self._bias_jpos
+
+        # Observation filter (applied AFTER noise so the order is "noisy sensor -> filter", exactly
+        # like hardware): quantize jpos to encoder resolution, derive jvel as a clamped finite-diff
+        # of the quantized jpos (not exact qvel), and EMA-low-pass both jvel and proj_grav. This is
+        # the deploy ObsBuilder reproduced in sim so the policy trains in the real, delayed loop.
+        if self.obs_filter:
+            if self.obs_encoder_quant > 0:
+                jpos = np.round(jpos / self.obs_encoder_quant) * self.obs_encoder_quant
+            if self.obs_jvel_finite_diff:
+                if self._obs_prev_jpos_q is None:
+                    raw_jv = np.zeros_like(jvel)
+                else:
+                    raw_jv = (jpos - self._obs_prev_jpos_q) / self._control_dt
+                self._obs_prev_jpos_q = jpos.copy()
+                raw_jv = np.clip(raw_jv, -self.obs_jvel_clamp, self.obs_jvel_clamp)
+            else:
+                raw_jv = jvel
+            aj = self._obs_jvel_alpha_ep
+            self._obs_jvel_ema = raw_jv if self._obs_jvel_ema is None else \
+                ((1.0 - aj) * self._obs_jvel_ema + aj * raw_jv)
+            jvel = self._obs_jvel_ema.astype(np.float32)
+            ap = self._obs_pg_alpha
+            self._obs_pg_ema = proj_grav if self._obs_pg_ema is None else \
+                ((1.0 - ap) * self._obs_pg_ema + ap * proj_grav)
+            n = float(np.linalg.norm(self._obs_pg_ema))
+            proj_grav = (self._obs_pg_ema / n if n > 1e-6 else self._obs_pg_ema).astype(np.float32)
 
         feats = [proj_grav, base_ang_vel, jpos, jvel, last_action]
         if self.include_foot_contact:


### PR DESCRIPTION
## Why
The standing policy stands in sim but drives a **~2–4 Hz body limit cycle** on the real robot. This session worked the problem by elimination and ruled out (with data): loop timing, IMU placement/polarity, gyro units, servo ring (clean 1st-order, matches the actuator-lag model), command chatter, joint stiffness, gyro/jvel feedback, and the npz export (byte-identical to SB3 through the deploy clip). A **sim pre-check killed the obs-delay hypothesis** — the current policy stays calm even with the deploy's filtering modeled in training.

**Root cause (best supported):** the custom model trains with **zero disturbances** (`random_height_init` gated off for custom, no push) → razor's-edge controller with no recovery basin; it's also **high-gain** (amplifies sensor noise into ~0.1 rad command jitter) and learned a **lopsided one-leg pose** (the model itself is symmetric).

## Changes — `standing_env.py` (all off-by-default)
- **push-recovery** — per-episode + in-episode root velocity kicks build a recovery basin.
- **`stance_balance_weight`** — rewards even weight on both feet + COM centered over them → balanced two-foot stand.
- **`raw_action_rate_penalty`** — charges the **pre-smoothing** action change (the existing penalty is on the smoothed action, so it never pressured the network to be low-gain).
- **`obs_filter`** — mirrors the deploy ObsBuilder in training with latency randomization. Built/validated but **unused** (pre-check showed obs delay isn't the cause); kept for future use.

## Config
`config/real_humanoid_balanced.yaml` — the retrain (push + stance 8 + raw-action-rate 25 + wider domain randomization), resumes the smooth model, `*_balanced` outputs.

## Deploy tooling
`deploy_standing.py`: loop-rate readout, `--zero-angvel`, `--zero-jvel`, `--freeze-after` (the diagnostics that isolated the failure). `servo_stiffness.py`: read/raise SCS position P/D gains (this firmware uses PID, not compliance slope).

## Validation
`ruff check .` clean. Env smoke-tested with the full config (obs stays 228-dim deployable). The retrain is run by the user; gates before deploy: sim kick-from-rest decays, sensitivity-probe action-std < 0.1, dry-run pose symmetric + `--freeze-after` stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)